### PR TITLE
fix: auto-update Homebrew formula SHA on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,7 @@ jobs:
             ## Installation
 
             ```bash
-            brew tap RunanywhereAI/rcli https://github.com/RunanywhereAI/RCLI.git
-            brew install rcli
+            brew install runanywhereai/rcli/rcli
             rcli setup  # download AI models (~1GB, one-time)
             ```
 
@@ -55,5 +54,24 @@ jobs:
             ```
             ${{ steps.package.outputs.sha256 }}
             ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Homebrew formula
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          SHA256="${{ steps.package.outputs.sha256 }}"
+          TARBALL_URL="https://github.com/RunanywhereAI/RCLI/releases/download/${GITHUB_REF_NAME}/rcli-${VERSION}-Darwin-arm64.tar.gz"
+
+          sed -i '' "s|url \".*\"|url \"${TARBALL_URL}\"|" Formula/rcli.rb
+          sed -i '' "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/rcli.rb
+          sed -i '' "s|version \".*\"|version \"${VERSION}\"|" Formula/rcli.rb
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout main
+          git add Formula/rcli.rb
+          git commit -m "formula: update to ${VERSION}"
+          git push origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- CI now automatically updates `Formula/rcli.rb` with the exact SHA256 from the build after uploading the release tarball
- Prevents checksum mismatch issues like #15 — no more manual formula edits
- Updated install instructions in release notes to use `brew install runanywhereai/rcli/rcli` (one-liner, always fetches latest)

Fixes #15

## What changed
**`.github/workflows/release.yml`** — added `Update Homebrew formula` step that:
1. Extracts version from the git tag
2. Uses the SHA256 computed during the Package step
3. Updates `url`, `sha256`, and `version` in `Formula/rcli.rb` via `sed`
4. Commits and pushes to `main`

## Rules going forward
1. **Never re-upload a tarball to an existing release** — bump the version instead
2. **Never manually edit `Formula/rcli.rb`** — CI owns it