### PR TITLE
test: e2e for MLX, NeuRT, and QHexRT

### DIFF
--- a/.agents/skills/rcli-architecture/SKILL.md
+++ b/.agents/skills/rcli-architecture/SKILL.md
@@ -19,7 +19,9 @@ of the SDK kit pin in `cmake/sdk-pin.cmake`.
 argv / flags / env
   -> src/commands/cmd_*.cpp     thin: parse → bootstrap() → one rac_* → render
   -> C++ desktop kit            catalog, download, lifecycle, generate, serve
-  -> engines (in the kit)       llama.cpp, Sherpa, ONNX, MLX (Apple host)
+  -> engines (in the kit)       llama.cpp, Sherpa, ONNX, MLX (Apple host);
+                                NeuRT / QHexRT only when the private overlay
+                                was applied at configure time
 ```
 
 The kit owns truth: models, backends, proto contracts, download, inference.
@@ -63,6 +65,9 @@ only for a C++-only compile loop.
 
 NeuRT image gen is `#if RCLI_HAS_NEURT` in `src/commands/cmd_image.cpp`, which
 is true only when the NeuRT overlay is applied. Public bottles stay OSS.
+`--engine qhexrt` / `qnn` / `npu` / `hexagon` map to
+`INFERENCE_FRAMEWORK_QHEXRT`. Local HNPU trees are inferred from `v75`/`v79`/
+`v81`, `context.bin`, or `*_HNPU` directory names.
 
 ## Skills trees
 

--- a/.agents/skills/rcli-e2e/SKILL.md
+++ b/.agents/skills/rcli-e2e/SKILL.md
@@ -21,8 +21,10 @@ for registrar symbols (`raMLXRegisterRuntime`, `rac_plugin_entry_neurt`,
 `rac_plugin_entry_qhexrt`, …) so a backends() listing cannot pass without
 the engine actually being linked into the bottle.
 
-Pass `RCLI_SDK_KIT` (or `CMAKE_PREFIX_PATH`) so the script can read
-`RunAnywhereConfig.cmake` `HAS_*` flags and stage Windows DLLs.
+Pass `RCLI_SDK_KIT` so overlay backends (`neurt` / `qhexrt`) are required
+when those libs are in the kit. `CMAKE_PREFIX_PATH` is only used for
+`HAS_*` flags and Windows DLL staging — an ambient overlay prefix must
+not make a public OSS bottle fail for missing NeuRT.
 
 ## What "green" means
 

--- a/.agents/skills/rcli-e2e/SKILL.md
+++ b/.agents/skills/rcli-e2e/SKILL.md
@@ -131,3 +131,50 @@ NeuRT / QHexRT only appear in `backends` when the overlay was applied.
 grepping packaged `HAS_NEURT FALSE` (that stays false; find_package flips it
 when the archive is present). Public CI must pass without overlays. Image gen
 (`cmd_image.cpp`) is compiled out unless NeuRT is present.
+
+## Device / overlay gotchas (0.5.1 + kit 0.20.28)
+
+Public bottles never list `neurt` or `qhexrt`. That is the product, not a
+test gap. Overlay-rebuild the product binary (`RCLI_APPLE_MLX_HOST=ON` on
+Mac; ARM64 MSVC + QHexRT overlay on Snapdragon).
+
+- **`CMAKE_PREFIX_PATH` is not an overlay opt-in.** Only `RCLI_SDK_KIT`
+  makes e2e require `neurt`/`qhexrt`. An ambient overlay prefix from a
+  previous rebuild will otherwise fail a public-bottle run.
+- **Binary assert:** never `nm | grep -q` under `pipefail` (SIGPIPE → false
+  FAIL). Stream `strings -a` / `nm -a`. Darwin MLX proof is
+  `mlx-swift_Cmlx.bundle` next to product `rcli` (`nm -gU` misses Swift
+  host symbols). First C++ `rac_plugin_register(mlx)` logs `-811`; Swift
+  callbacks then register MLX — noisy, not a miss.
+- **Windows ARM64 public/overlay kits have `HAS_LLAMACPP FALSE`.** Do not
+  require `llamacpp` in e2e. Overlay `rcli.exe` listing **only** `qhexrt`
+  (priority 150) is correct. On-disk GGUF (`qwen3.5-2b`) cannot run there.
+- **QHexRT generate needs QAIRT matching the device skel, not the overlay
+  DLL set.** Snapdragon X2 Elite / Hexagon v81: `QNN_SDK_ROOT` +
+  `ADSP_LIBRARY_PATH=%QNN_SDK_ROOT%\lib\hexagon-v81\unsigned`, copy
+  `aarch64-windows-msvc` `QnnHtp.dll` / `QnnHtpPrepare.dll` /
+  `QnnHtpV81Stub.dll` / `QnnHtpV81CalculatorStub.dll` / `QnnSystem.dll`
+  next to `rcli.exe`. Overlay 2.47 DLLs vs device 2.41 skels fail; QAIRT
+  **2.48** worked. Pass the `*_HNPU` directory (`--engine qhexrt`), not a
+  GGUF. FastRPC `openSession` timeouts (~90s) then user-driver fallback
+  are normal; a second generate while DSP is wedged fails with
+  `Skel failed to process context binary` / `0x3ea` — `taskkill rcli.exe`
+  and use a `.bat` with **fully expanded** `ADSP_LIBRARY_PATH` (nested
+  `%QNN_SDK_ROOT%` in `cmd /c "set A=…&& set B=%A%\…"` does not expand).
+- **VS on the ARM64 box may be 2026 / 18 Community**, not 2022:
+  `C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvarsarm64.bat`.
+  CMake/Ninja live under VS CMake extensions; they are not on default PATH.
+- **v0.20.28 Windows ARM64 public kit omits `libcurl.lib`.** Copy from
+  `arm64-windows-static` into the kit `lib/` before linking (fixed in the
+  SDK packager for the *next* kit; do not retag 0.20.28). RCLI already
+  links kit `libcurl.lib` when present.
+- **`rcli image generate` needs `--prompt` and `--out`**, not a positional
+  prompt. `--steps 4` is enough for a smoke PNG. Help exists on the public
+  bottle; real generate is compiled only with `RCLI_HAS_NEURT`.
+- **`sd15` catalog URL must be the compiled zip**, not the HF repo page
+  (HTML ~160 KB). Unzip to a tree with `TextEncoder.mlmodelc` /
+  `Unet.mlmodelc` / `VAEDecoder.mlmodelc` and pass that directory. COREML
+  / QHEXRT catalog rows register `ModelInfo` (folder), not the single-file
+  download factory — `rcli pull sd15` is not a substitute for the zip.
+- Published product bottles: macOS `rcli-$V-macos-arm64.tar.gz`, Windows
+  **x64** zip. There is no public Windows ARM64 bottle; NPU is overlay-only.

--- a/.agents/skills/rcli-e2e/SKILL.md
+++ b/.agents/skills/rcli-e2e/SKILL.md
@@ -6,7 +6,20 @@ description: Verify a built rcli binary against a pinned C++ desktop kit on macO
 # RCLI e2e
 
 Entry: `scripts/e2e.sh <path-to-rcli>`. Always runs `scripts/smoke.sh`. Set
-`RCLI_E2E_MODEL` for download + generate (needs network + disk).
+`RCLI_E2E_MODEL` for download + generate (needs network + disk). Overlay
+backends also have dedicated knobs that default to skip in public CI:
+
+| Env | When | Example |
+|---|---|---|
+| `RCLI_E2E_MODEL` | any LLM | `mlx-qwen3` |
+| `RCLI_E2E_MLX_MODEL` | product `rcli` on Darwin arm64 | `mlx-qwen3` |
+| `RCLI_E2E_NEURT_MODEL` | overlay kit with `librac_backend_neurt.a` | `sd15` |
+| `RCLI_E2E_QHEXRT_MODEL` | overlay kit with `rac_backend_qhexrt.lib` | local QNN-context path |
+
+`scripts/assert-binary-backends.sh` greps `nm`/`llvm-nm`/`dumpbin`/`strings`
+for registrar symbols (`raMLXRegisterRuntime`, `rac_plugin_entry_neurt`,
+`rac_plugin_entry_qhexrt`, …) so a backends() listing cannot pass without
+the engine actually being linked into the bottle.
 
 Pass `RCLI_SDK_KIT` (or `CMAKE_PREFIX_PATH`) so the script can read
 `RunAnywhereConfig.cmake` `HAS_*` flags and stage Windows DLLs.
@@ -17,10 +30,13 @@ Pass `RCLI_SDK_KIT` (or `CMAKE_PREFIX_PATH`) so the script can read
 
 | Condition | Required `rcli --json backends` name |
 |---|---|
-| always | `llamacpp` |
-| `RunAnywhere_HAS_ONNX` TRUE (or no kit cfg) | `onnx` |
-| `RunAnywhere_HAS_SHERPA` TRUE (or no kit cfg) | `sherpa` |
+| no kit Config (public OSS bottle) | `llamacpp` + `onnx` + `sherpa` |
+| kit `RunAnywhere_HAS_LLAMACPP` TRUE | `llamacpp` |
+| kit `RunAnywhere_HAS_ONNX` TRUE | `onnx` |
+| kit `RunAnywhere_HAS_SHERPA` TRUE | `sherpa` |
 | Darwin arm64 product binary `rcli` (not `rcli-cxx`) | `mlx` |
+| overlay `lib/librac_backend_neurt.a` / `rac_backend_neurt.lib` | `neurt` |
+| overlay `lib/librac_backend_qhexrt.a` / `rac_backend_qhexrt.lib` | `qhexrt` |
 
 Do **not** drop sherpa from the expected list to make 0.20.26 Windows green
 while `HAS_SHERPA` is TRUE. That kit compiled sherpa with speech ops off

--- a/.agents/skills/rcli-kit-pin/SKILL.md
+++ b/.agents/skills/rcli-kit-pin/SKILL.md
@@ -66,6 +66,16 @@ Not part of the pin. Applied after extract:
 QHexRT is Windows ARM64 only. Public bottles must stay OSS — never bake overlay
 bytes into a Homebrew bottle or a public GitHub Release asset.
 
+Windows ARM64 **public** kit is commons-only (no llama.cpp). Overlay apply
+then rebuild product `rcli.exe`. `v0.20.28` ARM64 kits are missing
+`lib/libcurl.lib` (packager only globbed x64-windows-static) — copy from
+vcpkg `arm64-windows-static` until the next SDK kit train. RCLI
+`cmake/RunAnywhereSDK.cmake` links that import lib when present.
+
+NeuRT: public mac bottle has MLX, not NeuRT. Overlay tarball +
+`RCLI_APPLE_MLX_HOST=ON` rebuild. See **rcli-e2e** for QAIRT / SD15 / DSP
+gotchas; do not weaken public CI to require overlays.
+
 ## Verify
 
 ```bash

--- a/.agents/skills/rcli-release/SKILL.md
+++ b/.agents/skills/rcli-release/SKILL.md
@@ -100,6 +100,11 @@ export RCLI_PRIVATE_OVERLAY=/path/to/RunAnywhere-cpp-desktop-macos-arm64-neurt-p
 `RCLI_REQUIRE_PRIVATE=1` fails closed when the overlay is missing. Default CI
 must pass without it.
 
+Device proof is not CI: rebuild overlay `rcli` on a Mac (NeuRT image gen) and
+on Snapdragon ARM64 Windows (QHexRT). Match QAIRT to the device Hexagon skel
+(`ADSP_LIBRARY_PATH`); see **rcli-e2e**. Public `v0.5.1` bottles are OSS —
+NeuRT/QHexRT will never appear in `rcli backends` on those artifacts.
+
 ## Do not
 
 - Attach `rcli-*` assets onto an SDK GitHub Release.

--- a/.claude/skills/rcli-architecture/SKILL.md
+++ b/.claude/skills/rcli-architecture/SKILL.md
@@ -19,7 +19,9 @@ of the SDK kit pin in `cmake/sdk-pin.cmake`.
 argv / flags / env
   -> src/commands/cmd_*.cpp     thin: parse → bootstrap() → one rac_* → render
   -> C++ desktop kit            catalog, download, lifecycle, generate, serve
-  -> engines (in the kit)       llama.cpp, Sherpa, ONNX, MLX (Apple host)
+  -> engines (in the kit)       llama.cpp, Sherpa, ONNX, MLX (Apple host);
+                                NeuRT / QHexRT only when the private overlay
+                                was applied at configure time
 ```
 
 The kit owns truth: models, backends, proto contracts, download, inference.
@@ -63,6 +65,9 @@ only for a C++-only compile loop.
 
 NeuRT image gen is `#if RCLI_HAS_NEURT` in `src/commands/cmd_image.cpp`, which
 is true only when the NeuRT overlay is applied. Public bottles stay OSS.
+`--engine qhexrt` / `qnn` / `npu` / `hexagon` map to
+`INFERENCE_FRAMEWORK_QHEXRT`. Local HNPU trees are inferred from `v75`/`v79`/
+`v81`, `context.bin`, or `*_HNPU` directory names.
 
 ## Skills trees
 

--- a/.claude/skills/rcli-e2e/SKILL.md
+++ b/.claude/skills/rcli-e2e/SKILL.md
@@ -21,8 +21,10 @@ for registrar symbols (`raMLXRegisterRuntime`, `rac_plugin_entry_neurt`,
 `rac_plugin_entry_qhexrt`, …) so a backends() listing cannot pass without
 the engine actually being linked into the bottle.
 
-Pass `RCLI_SDK_KIT` (or `CMAKE_PREFIX_PATH`) so the script can read
-`RunAnywhereConfig.cmake` `HAS_*` flags and stage Windows DLLs.
+Pass `RCLI_SDK_KIT` so overlay backends (`neurt` / `qhexrt`) are required
+when those libs are in the kit. `CMAKE_PREFIX_PATH` is only used for
+`HAS_*` flags and Windows DLL staging — an ambient overlay prefix must
+not make a public OSS bottle fail for missing NeuRT.
 
 ## What "green" means
 

--- a/.claude/skills/rcli-e2e/SKILL.md
+++ b/.claude/skills/rcli-e2e/SKILL.md
@@ -131,3 +131,50 @@ NeuRT / QHexRT only appear in `backends` when the overlay was applied.
 grepping packaged `HAS_NEURT FALSE` (that stays false; find_package flips it
 when the archive is present). Public CI must pass without overlays. Image gen
 (`cmd_image.cpp`) is compiled out unless NeuRT is present.
+
+## Device / overlay gotchas (0.5.1 + kit 0.20.28)
+
+Public bottles never list `neurt` or `qhexrt`. That is the product, not a
+test gap. Overlay-rebuild the product binary (`RCLI_APPLE_MLX_HOST=ON` on
+Mac; ARM64 MSVC + QHexRT overlay on Snapdragon).
+
+- **`CMAKE_PREFIX_PATH` is not an overlay opt-in.** Only `RCLI_SDK_KIT`
+  makes e2e require `neurt`/`qhexrt`. An ambient overlay prefix from a
+  previous rebuild will otherwise fail a public-bottle run.
+- **Binary assert:** never `nm | grep -q` under `pipefail` (SIGPIPE → false
+  FAIL). Stream `strings -a` / `nm -a`. Darwin MLX proof is
+  `mlx-swift_Cmlx.bundle` next to product `rcli` (`nm -gU` misses Swift
+  host symbols). First C++ `rac_plugin_register(mlx)` logs `-811`; Swift
+  callbacks then register MLX — noisy, not a miss.
+- **Windows ARM64 public/overlay kits have `HAS_LLAMACPP FALSE`.** Do not
+  require `llamacpp` in e2e. Overlay `rcli.exe` listing **only** `qhexrt`
+  (priority 150) is correct. On-disk GGUF (`qwen3.5-2b`) cannot run there.
+- **QHexRT generate needs QAIRT matching the device skel, not the overlay
+  DLL set.** Snapdragon X2 Elite / Hexagon v81: `QNN_SDK_ROOT` +
+  `ADSP_LIBRARY_PATH=%QNN_SDK_ROOT%\lib\hexagon-v81\unsigned`, copy
+  `aarch64-windows-msvc` `QnnHtp.dll` / `QnnHtpPrepare.dll` /
+  `QnnHtpV81Stub.dll` / `QnnHtpV81CalculatorStub.dll` / `QnnSystem.dll`
+  next to `rcli.exe`. Overlay 2.47 DLLs vs device 2.41 skels fail; QAIRT
+  **2.48** worked. Pass the `*_HNPU` directory (`--engine qhexrt`), not a
+  GGUF. FastRPC `openSession` timeouts (~90s) then user-driver fallback
+  are normal; a second generate while DSP is wedged fails with
+  `Skel failed to process context binary` / `0x3ea` — `taskkill rcli.exe`
+  and use a `.bat` with **fully expanded** `ADSP_LIBRARY_PATH` (nested
+  `%QNN_SDK_ROOT%` in `cmd /c "set A=…&& set B=%A%\…"` does not expand).
+- **VS on the ARM64 box may be 2026 / 18 Community**, not 2022:
+  `C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvarsarm64.bat`.
+  CMake/Ninja live under VS CMake extensions; they are not on default PATH.
+- **v0.20.28 Windows ARM64 public kit omits `libcurl.lib`.** Copy from
+  `arm64-windows-static` into the kit `lib/` before linking (fixed in the
+  SDK packager for the *next* kit; do not retag 0.20.28). RCLI already
+  links kit `libcurl.lib` when present.
+- **`rcli image generate` needs `--prompt` and `--out`**, not a positional
+  prompt. `--steps 4` is enough for a smoke PNG. Help exists on the public
+  bottle; real generate is compiled only with `RCLI_HAS_NEURT`.
+- **`sd15` catalog URL must be the compiled zip**, not the HF repo page
+  (HTML ~160 KB). Unzip to a tree with `TextEncoder.mlmodelc` /
+  `Unet.mlmodelc` / `VAEDecoder.mlmodelc` and pass that directory. COREML
+  / QHEXRT catalog rows register `ModelInfo` (folder), not the single-file
+  download factory — `rcli pull sd15` is not a substitute for the zip.
+- Published product bottles: macOS `rcli-$V-macos-arm64.tar.gz`, Windows
+  **x64** zip. There is no public Windows ARM64 bottle; NPU is overlay-only.

--- a/.claude/skills/rcli-e2e/SKILL.md
+++ b/.claude/skills/rcli-e2e/SKILL.md
@@ -6,7 +6,20 @@ description: Verify a built rcli binary against a pinned C++ desktop kit on macO
 # RCLI e2e
 
 Entry: `scripts/e2e.sh <path-to-rcli>`. Always runs `scripts/smoke.sh`. Set
-`RCLI_E2E_MODEL` for download + generate (needs network + disk).
+`RCLI_E2E_MODEL` for download + generate (needs network + disk). Overlay
+backends also have dedicated knobs that default to skip in public CI:
+
+| Env | When | Example |
+|---|---|---|
+| `RCLI_E2E_MODEL` | any LLM | `mlx-qwen3` |
+| `RCLI_E2E_MLX_MODEL` | product `rcli` on Darwin arm64 | `mlx-qwen3` |
+| `RCLI_E2E_NEURT_MODEL` | overlay kit with `librac_backend_neurt.a` | `sd15` |
+| `RCLI_E2E_QHEXRT_MODEL` | overlay kit with `rac_backend_qhexrt.lib` | local QNN-context path |
+
+`scripts/assert-binary-backends.sh` greps `nm`/`llvm-nm`/`dumpbin`/`strings`
+for registrar symbols (`raMLXRegisterRuntime`, `rac_plugin_entry_neurt`,
+`rac_plugin_entry_qhexrt`, …) so a backends() listing cannot pass without
+the engine actually being linked into the bottle.
 
 Pass `RCLI_SDK_KIT` (or `CMAKE_PREFIX_PATH`) so the script can read
 `RunAnywhereConfig.cmake` `HAS_*` flags and stage Windows DLLs.
@@ -17,10 +30,13 @@ Pass `RCLI_SDK_KIT` (or `CMAKE_PREFIX_PATH`) so the script can read
 
 | Condition | Required `rcli --json backends` name |
 |---|---|
-| always | `llamacpp` |
-| `RunAnywhere_HAS_ONNX` TRUE (or no kit cfg) | `onnx` |
-| `RunAnywhere_HAS_SHERPA` TRUE (or no kit cfg) | `sherpa` |
+| no kit Config (public OSS bottle) | `llamacpp` + `onnx` + `sherpa` |
+| kit `RunAnywhere_HAS_LLAMACPP` TRUE | `llamacpp` |
+| kit `RunAnywhere_HAS_ONNX` TRUE | `onnx` |
+| kit `RunAnywhere_HAS_SHERPA` TRUE | `sherpa` |
 | Darwin arm64 product binary `rcli` (not `rcli-cxx`) | `mlx` |
+| overlay `lib/librac_backend_neurt.a` / `rac_backend_neurt.lib` | `neurt` |
+| overlay `lib/librac_backend_qhexrt.a` / `rac_backend_qhexrt.lib` | `qhexrt` |
 
 Do **not** drop sherpa from the expected list to make 0.20.26 Windows green
 while `HAS_SHERPA` is TRUE. That kit compiled sherpa with speech ops off

--- a/.claude/skills/rcli-kit-pin/SKILL.md
+++ b/.claude/skills/rcli-kit-pin/SKILL.md
@@ -66,6 +66,16 @@ Not part of the pin. Applied after extract:
 QHexRT is Windows ARM64 only. Public bottles must stay OSS — never bake overlay
 bytes into a Homebrew bottle or a public GitHub Release asset.
 
+Windows ARM64 **public** kit is commons-only (no llama.cpp). Overlay apply
+then rebuild product `rcli.exe`. `v0.20.28` ARM64 kits are missing
+`lib/libcurl.lib` (packager only globbed x64-windows-static) — copy from
+vcpkg `arm64-windows-static` until the next SDK kit train. RCLI
+`cmake/RunAnywhereSDK.cmake` links that import lib when present.
+
+NeuRT: public mac bottle has MLX, not NeuRT. Overlay tarball +
+`RCLI_APPLE_MLX_HOST=ON` rebuild. See **rcli-e2e** for QAIRT / SD15 / DSP
+gotchas; do not weaken public CI to require overlays.
+
 ## Verify
 
 ```bash

--- a/.claude/skills/rcli-release/SKILL.md
+++ b/.claude/skills/rcli-release/SKILL.md
@@ -100,6 +100,11 @@ export RCLI_PRIVATE_OVERLAY=/path/to/RunAnywhere-cpp-desktop-macos-arm64-neurt-p
 `RCLI_REQUIRE_PRIVATE=1` fails closed when the overlay is missing. Default CI
 must pass without it.
 
+Device proof is not CI: rebuild overlay `rcli` on a Mac (NeuRT image gen) and
+on Snapdragon ARM64 Windows (QHexRT). Match QAIRT to the device Hexagon skel
+(`ADSP_LIBRARY_PATH`); see **rcli-e2e**. Public `v0.5.1` bottles are OSS —
+NeuRT/QHexRT will never appear in `rcli backends` on those artifacts.
+
 ## Do not
 
 - Attach `rcli-*` assets onto an SDK GitHub Release.

--- a/cmake/RunAnywhereSDK.cmake
+++ b/cmake/RunAnywhereSDK.cmake
@@ -96,6 +96,14 @@ if(WIN32)
                 INTERFACE_LINK_LIBRARIES "${RunAnywhere_LIBRARY_DIR}/onnxruntime.lib")
         endif()
     endif()
+    if(DEFINED RunAnywhere_LIBRARY_DIR AND EXISTS "${RunAnywhere_LIBRARY_DIR}/libcurl.lib")
+        get_target_property(_rcli_ra_ifaces RunAnywhere::commons INTERFACE_LINK_LIBRARIES)
+        set(_rcli_ra_ifaces "${_rcli_ra_ifaces}")
+        if(NOT _rcli_ra_ifaces MATCHES "libcurl\\.lib")
+            set_property(TARGET RunAnywhere::commons APPEND PROPERTY
+                INTERFACE_LINK_LIBRARIES "${RunAnywhere_LIBRARY_DIR}/libcurl.lib")
+        endif()
+    endif()
     # Static libcurl/libarchive in 0.20.26 kits omit these Windows imports.
     # Keep them here until a later kit bakes them into SYSTEM_LIBS.
     foreach(_sys IN ITEMS iphlpapi xmllite ole32)

--- a/scripts/assert-binary-backends.sh
+++ b/scripts/assert-binary-backends.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Assert the binary actually contains the engines `rcli backends` claims.
+#
+#   scripts/assert-binary-backends.sh <path-to-rcli> <name> [<name>...]
+#
+# Release bottles (especially the Swift MLX host) strip global C symbols.
+# Stream nm/strings into grep. `grep -q` closes the pipe early; with
+# `set -o pipefail` that looks like failure (nm SIGPIPE). Disable pipefail
+# for the scan.
+set -euo pipefail
+
+RCLI="${1:?usage: assert-binary-backends.sh <rcli> <name>...}"
+shift
+if [[ $# -eq 0 ]]; then
+    echo "usage: assert-binary-backends.sh <rcli> <name>..." >&2
+    exit 2
+fi
+if [[ ! -e "${RCLI}" ]]; then
+    echo "not found: ${RCLI}" >&2
+    exit 1
+fi
+
+has_tool=0
+strings_bin=""
+for cand in strings /usr/bin/strings "/c/Program Files/Git/usr/bin/strings" \
+        "/usr/bin/x86_64-pc-msys-strings"; do
+    if command -v "${cand}" >/dev/null 2>&1 || [[ -x "${cand}" ]]; then
+        strings_bin="${cand}"
+        has_tool=1
+        break
+    fi
+done
+command -v nm >/dev/null 2>&1 && has_tool=1
+command -v dumpbin >/dev/null 2>&1 && has_tool=1
+if [[ "${has_tool}" -eq 0 ]]; then
+    echo "skip  binary-backends (no nm/dumpbin/strings)"
+    exit 0
+fi
+
+need_pat() {
+    case "$1" in
+        mlx) echo 'raMLXRegisterRuntime|rac_mlx_set_callbacks|MLXRuntime|mlx-swift_Cmlx' ;;
+        neurt) echo 'rac_plugin_entry_neurt|rac_backend_neurt|libneurt_' ;;
+        qhexrt) echo 'rac_plugin_entry_qhexrt|rac_backend_qhexrt|QnnHtp' ;;
+        llamacpp) echo 'rac_plugin_entry_llamacpp|rac_backend_llamacpp_register|g_llamacpp_' ;;
+        sherpa) echo 'rac_plugin_entry_sherpa|rac_backend_sherpa|SherpaOnnx|g_sherpa_stt_ops' ;;
+        onnx) echo 'rac_plugin_entry_onnx|rac_backend_onnx|OrtGetApiBase' ;;
+        *) echo "" ;;
+    esac
+}
+
+# Returns 0 if pat matches the image. Never trips pipefail on a real hit.
+blob_match() {
+    local pat="$1"
+    set +e
+    set +o pipefail
+    if [[ -n "${strings_bin}" ]]; then
+        "${strings_bin}" -a "${RCLI}" 2>/dev/null | grep -a -qiE "${pat}"
+        if [[ $? -eq 0 ]]; then
+            set -e
+            set -o pipefail
+            return 0
+        fi
+    fi
+    if command -v nm >/dev/null 2>&1; then
+        nm -a "${RCLI}" 2>/dev/null | grep -a -qiE "${pat}"
+        if [[ $? -eq 0 ]]; then
+            set -e
+            set -o pipefail
+            return 0
+        fi
+    fi
+    if command -v dumpbin >/dev/null 2>&1; then
+        dumpbin /ALL "${RCLI}" 2>/dev/null | grep -a -qiE "${pat}"
+        if [[ $? -eq 0 ]]; then
+            set -e
+            set -o pipefail
+            return 0
+        fi
+    fi
+    set -e
+    set -o pipefail
+    return 1
+}
+
+fail=0
+exe_dir="$(cd "$(dirname "${RCLI}")" && pwd)"
+for name in "$@"; do
+    if [[ "${name}" == mlx && -d "${exe_dir}/mlx-swift_Cmlx.bundle" ]]; then
+        echo "  ok    binary has mlx (mlx-swift_Cmlx.bundle)"
+        continue
+    fi
+    pat="$(need_pat "${name}")"
+    if [[ -z "${pat}" ]]; then
+        continue
+    fi
+    if blob_match "${pat}"; then
+        echo "  ok    binary has ${name}"
+    else
+        echo "  FAIL  binary missing ${name} (${pat})"
+        fail=1
+    fi
+done
+exit "${fail}"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -102,12 +102,17 @@ if [[ "$(uname -s)" == Darwin && "$(uname -m)" == arm64 && "${base}" == "rcli" ]
 fi
 # Overlay archives flip HAS_NEURT/HAS_QHEXRT at find_package time, but the
 # packaged Config.cmake still says FALSE. Presence of the backend library is
-# the source of truth (same as RunAnywhereConfig.cmake). Public CI has neither.
-if [[ -n "${kit_root}" ]]; then
-    if [[ -f "${kit_root}/lib/librac_backend_neurt.a" || -f "${kit_root}/lib/rac_backend_neurt.lib" ]]; then
+# the source of truth. Only RCLI_SDK_KIT counts — ambient CMAKE_PREFIX_PATH
+# from an overlay rebuild must not fail a public-bottle e2e.
+overlay_root="${RCLI_SDK_KIT-}"
+if [[ -n "${overlay_root}" ]] && command -v cygpath >/dev/null 2>&1; then
+    overlay_root="$(cygpath -u "${overlay_root}")"
+fi
+if [[ -n "${overlay_root}" ]]; then
+    if [[ -f "${overlay_root}/lib/librac_backend_neurt.a" || -f "${overlay_root}/lib/rac_backend_neurt.lib" ]]; then
         expected_backends+=(neurt)
     fi
-    if [[ -f "${kit_root}/lib/librac_backend_qhexrt.a" || -f "${kit_root}/lib/rac_backend_qhexrt.lib" ]]; then
+    if [[ -f "${overlay_root}/lib/librac_backend_qhexrt.a" || -f "${overlay_root}/lib/rac_backend_qhexrt.lib" ]]; then
         expected_backends+=(qhexrt)
     fi
 fi

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -5,6 +5,8 @@
 #
 # Always runs scripts/smoke.sh (no model download). Set RCLI_E2E_MODEL to also
 # pull a catalog model and run one generation — that needs network + disk.
+# Overlay backends: RCLI_E2E_MLX_MODEL, RCLI_E2E_NEURT_MODEL, RCLI_E2E_QHEXRT_MODEL.
+# CMAKE_PREFIX_PATH is optional; RCLI_SDK_KIT is preferred. Unset is fine.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -19,7 +21,8 @@ if [[ ! -x "${RCLI}" && "${RCLI}" != *.exe && "${RCLI}" != *.EXE ]]; then
 fi
 
 kit_cfg=""
-kit_root="${RCLI_SDK_KIT:-${CMAKE_PREFIX_PATH%%:*}}"
+kit_root="${RCLI_SDK_KIT:-${CMAKE_PREFIX_PATH-}}"
+kit_root="${kit_root%%:*}"
 if [[ -n "${kit_root}" ]] && command -v cygpath >/dev/null 2>&1; then
     kit_root="$(cygpath -u "${kit_root}")"
 fi
@@ -71,17 +74,26 @@ check "info" "${RCLI}" info
 # may only advertise llamacpp; 0.20.28+ kits advertise onnx + sherpa too.
 # Product `rcli` on Apple Silicon also includes MLX. Intermediate `rcli-cxx` does not.
 
-expected_backends=(llamacpp)
+expected_backends=()
 kit_flag_true() {
     local key="$1"
     [[ -n "${kit_cfg}" ]] || return 0
     grep -Eq "set\\(${key}[[:space:]]+(TRUE|ON|1)\\)" "${kit_cfg}"
 }
-if [[ -z "${kit_cfg}" ]] || kit_flag_true RunAnywhere_HAS_ONNX; then
-    expected_backends+=(onnx)
-fi
-if [[ -z "${kit_cfg}" ]] || kit_flag_true RunAnywhere_HAS_SHERPA; then
-    expected_backends+=(sherpa)
+# When the kit Config is present, honor HAS_* (Windows ARM64 public kits have
+# no llama.cpp/ONNX/Sherpa). Without a kit, assume the public OSS bottle.
+if [[ -z "${kit_cfg}" ]]; then
+    expected_backends=(llamacpp onnx sherpa)
+else
+    if kit_flag_true RunAnywhere_HAS_LLAMACPP; then
+        expected_backends+=(llamacpp)
+    fi
+    if kit_flag_true RunAnywhere_HAS_ONNX; then
+        expected_backends+=(onnx)
+    fi
+    if kit_flag_true RunAnywhere_HAS_SHERPA; then
+        expected_backends+=(sherpa)
+    fi
 fi
 base="$(basename "${RCLI}")"
 base="${base%.exe}"
@@ -99,36 +111,102 @@ if [[ -n "${kit_root}" ]]; then
         expected_backends+=(qhexrt)
     fi
 fi
-if bash "${ROOT}/scripts/assert-backends.sh" "${RCLI}" "${expected_backends[@]}"; then
+if [[ ${#expected_backends[@]} -eq 0 ]]; then
+    echo "  skip  backends (kit has no engines)"
+elif bash "${ROOT}/scripts/assert-backends.sh" "${RCLI}" "${expected_backends[@]}"; then
     echo "  ok    backends ${expected_backends[*]}"
 else
     echo "  FAIL  backends ${expected_backends[*]}"
     fail=1
 fi
+if [[ ${#expected_backends[@]} -gt 0 ]]; then
+    if bash "${ROOT}/scripts/assert-binary-backends.sh" "${RCLI}" "${expected_backends[@]}"; then
+        echo "  ok    binary ${expected_backends[*]}"
+    else
+        echo "  FAIL  binary ${expected_backends[*]}"
+        fail=1
+    fi
+fi
 if "${RCLI}" models list --help >/dev/null 2>&1; then
     check "models list" "${RCLI}" models list
 fi
 
-if [[ -n "${RCLI_E2E_MODEL:-}" ]]; then
-    echo "e2e (model): ${RCLI_E2E_MODEL}"
+# Per-backend help surfaces that only compile in when the engine is linked.
+for name in "${expected_backends[@]}"; do
+    case "${name}" in
+        neurt)
+            check "image generate --help" "${RCLI}" image generate --help
+            ;;
+        mlx|qhexrt)
+            check "run --help" "${RCLI}" run --help
+            ;;
+    esac
+done
+
+roundtrip() {
+    local label="$1"
+    local model="$2"
+    local kind="${3:-llm}"
+    echo "e2e (${label}): ${model}"
     export RUNANYWHERE_HOME="${RUNANYWHERE_HOME:-$(mktemp -d)}"
-    if "${RCLI}" models download "${RCLI_E2E_MODEL}"; then
-        echo "  ok    models download ${RCLI_E2E_MODEL}"
-    elif "${RCLI}" pull "${RCLI_E2E_MODEL}"; then
-        echo "  ok    pull ${RCLI_E2E_MODEL}"
+    if [[ -e "${model}" ]]; then
+        echo "  ok    local path ${model}"
+    elif "${RCLI}" models download "${model}"; then
+        echo "  ok    models download ${model}"
+    elif "${RCLI}" pull "${model}"; then
+        echo "  ok    pull ${model}"
     else
-        echo "  FAIL  download ${RCLI_E2E_MODEL}"
-        fail=1
+        echo "  FAIL  download ${model}"
+        return 1
     fi
-    if "${RCLI}" llm generate --model "${RCLI_E2E_MODEL}" "Reply with exactly: ok" --max-output-tokens 8 >/dev/null 2>&1 \
-        || "${RCLI}" run "${RCLI_E2E_MODEL}" "Reply with exactly: ok" >/dev/null 2>&1; then
-        echo "  ok    generate"
-    else
-        echo "  FAIL  generate"
-        fail=1
-    fi
+    case "${kind}" in
+        image)
+            local out
+            out="$(mktemp -t rcli-e2e-img).png"
+            if "${RCLI}" image generate --model "${model}" --prompt "a red square" --out "${out}" --steps 4 >/dev/null 2>&1 \
+                && [[ -s "${out}" ]]; then
+                echo "  ok    image generate"
+                rm -f "${out}"
+                return 0
+            fi
+            echo "  FAIL  image generate"
+            return 1
+            ;;
+        *)
+            if "${RCLI}" llm generate --model "${model}" "Reply with exactly: ok" --max-output-tokens 8 >/dev/null 2>&1 \
+                || "${RCLI}" run "${model}" "Reply with exactly: ok" >/dev/null 2>&1; then
+                echo "  ok    generate"
+                return 0
+            fi
+            echo "  FAIL  generate"
+            return 1
+            ;;
+    esac
+}
+
+# Default one-model path (any backend). Specific engines below can also be set.
+if [[ -n "${RCLI_E2E_MODEL:-}" ]]; then
+    roundtrip "model" "${RCLI_E2E_MODEL}" llm || fail=1
 else
     echo "  skip  model round-trip (set RCLI_E2E_MODEL to enable)"
+fi
+
+# Newly added backends: run a real model when the tester asks, never in
+# default CI (downloads are large; NeuRT/QHexRT overlays are private).
+if [[ -n "${RCLI_E2E_MLX_MODEL:-}" ]]; then
+    roundtrip "mlx" "${RCLI_E2E_MLX_MODEL}" llm || fail=1
+elif printf '%s\n' "${expected_backends[@]}" | grep -qx mlx; then
+    echo "  skip  mlx round-trip (set RCLI_E2E_MLX_MODEL, e.g. mlx-qwen3)"
+fi
+if [[ -n "${RCLI_E2E_NEURT_MODEL:-}" ]]; then
+    roundtrip "neurt" "${RCLI_E2E_NEURT_MODEL}" image || fail=1
+elif printf '%s\n' "${expected_backends[@]}" | grep -qx neurt; then
+    echo "  skip  neurt round-trip (set RCLI_E2E_NEURT_MODEL, e.g. sd15)"
+fi
+if [[ -n "${RCLI_E2E_QHEXRT_MODEL:-}" ]]; then
+    roundtrip "qhexrt" "${RCLI_E2E_QHEXRT_MODEL}" llm || fail=1
+elif printf '%s\n' "${expected_backends[@]}" | grep -qx qhexrt; then
+    echo "  skip  qhexrt round-trip (set RCLI_E2E_QHEXRT_MODEL)"
 fi
 
 exit "${fail}"

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1669,11 +1669,15 @@ constexpr CatalogEntry kCatalog[] = {
     // and `rcli list` shows it. The palettized CoreML bundle is a directory of
     // compiled .mlmodelc sub-models served by the `coreml` engine; a
     // pre-fetched bundle can also be passed to `--model` as a local path.
+    // The Hugging Face *repo page* is HTML (~160 KB) and is not a model.
+    // Point at the compiled split-einsum zip (~1.5 GB).
     {"stable-diffusion-v1-5-coreml", "sd15", "Stable Diffusion 1.5 (CoreML)",
      v1::MODEL_CATEGORY_IMAGE_GENERATION, v1::INFERENCE_FRAMEWORK_COREML,
      v1::MODEL_FORMAT_MLPACKAGE,
-     "https://huggingface.co/apple/coreml-stable-diffusion-v1-5-palettized",
-     nullptr, 0, 1200 * MB, 0, false},
+     "https://huggingface.co/apple/coreml-stable-diffusion-v1-5-palettized/"
+     "resolve/main/"
+     "coreml-stable-diffusion-v1-5-palettized_split_einsum_v2_compiled.zip",
+     nullptr, 0, 1500 * MB, 0, false},
 
     // --- MLX (Apple Silicon / Apple GPU via mlx-swift-lm) ---
     {"mlx-qwen3-0.6b-4bit", "mlx-qwen3", "Qwen3 0.6B 4-bit (MLX)",

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1853,6 +1853,33 @@ constexpr CatalogEntry kCatalog[] = {
      v1::INFERENCE_FRAMEWORK_MLX, v1::MODEL_FORMAT_SAFETENSORS, nullptr,
      kMlxGranite4_1_30BFiles, 10, 18041976573LL, 4096, false},
 
+    // --- QHexRT (Snapdragon Hexagon NPU; Windows ARM64 overlay) ---
+    // Ids match engines/qhexrt/qhexrt_model_catalog.cpp so pull/lifecycle
+    // resolve the same native catalog the Android/Flutter apps use. Folder
+    // URLs are registered as ModelInfo (same path as CoreML diffusion) —
+    // the QNN context tree is fetched by the QHexRT bundle policy or passed
+    // as a local `*_HNPU` directory to `rcli run`.
+    {"lfm2_5_230m", "lfm2-230m-npu", "LFM2.5 230M (Hexagon NPU)",
+     v1::MODEL_CATEGORY_LANGUAGE, v1::INFERENCE_FRAMEWORK_QHEXRT,
+     v1::MODEL_FORMAT_QNN_CONTEXT,
+     "https://huggingface.co/runanywhere/lfm2_5_230m_HNPU", nullptr, 0, 0, 0,
+     false},
+    {"lfm2_5_350m", "lfm2-350m-npu", "LFM2.5 350M (Hexagon NPU)",
+     v1::MODEL_CATEGORY_LANGUAGE, v1::INFERENCE_FRAMEWORK_QHEXRT,
+     v1::MODEL_FORMAT_QNN_CONTEXT,
+     "https://huggingface.co/runanywhere/lfm2_5_350m_HNPU", nullptr, 0, 0, 0,
+     false},
+    {"lfm2_5_1_2b_thinking", "lfm2-1.2b-npu",
+     "LFM2.5 1.2B Thinking (Hexagon NPU)", v1::MODEL_CATEGORY_LANGUAGE,
+     v1::INFERENCE_FRAMEWORK_QHEXRT, v1::MODEL_FORMAT_QNN_CONTEXT,
+     "https://huggingface.co/runanywhere/lfm2_5_1_2b_thinking_HNPU", nullptr, 0,
+     0, 0, true},
+    {"qwen3_5_2b", "qwen3.5-2b-npu", "Qwen3.5 2B (Hexagon NPU)",
+     v1::MODEL_CATEGORY_LANGUAGE, v1::INFERENCE_FRAMEWORK_QHEXRT,
+     v1::MODEL_FORMAT_QNN_CONTEXT,
+     "https://huggingface.co/runanywhere/qwen3_5_2b_HNPU", nullptr, 0, 0, 0,
+     false},
+
     // Muse Glimmer 30B (MLX) and Nemotron-3-Nano-Omni-30B-A3B-Reasoning (MLX)
     // are deliberately NOT registered here. Their config.json model_types
     // ("muse_glimmer" and "NemotronH_Nano_Omni_Reasoning_V3" respectively) are
@@ -1872,7 +1899,11 @@ rac_result_t register_entry(const CatalogEntry &entry) {
   // Register the ModelInfo directly so the id resolves in the general registry
   // (and `rcli list` shows it); the bundle itself is fetched by the diffusion
   // pipeline or supplied to `rcli image --model <local path>`.
-  if (entry.framework == v1::INFERENCE_FRAMEWORK_COREML) {
+  if (entry.framework == v1::INFERENCE_FRAMEWORK_COREML ||
+      entry.framework == v1::INFERENCE_FRAMEWORK_QHEXRT) {
+    // CoreML bundles and QHexRT HNPU folders don't fit the single-file
+    // download-factory grammar. Register ModelInfo so `rcli list` / `rcli run`
+    // resolve the id; the tree is fetched by the engine or passed as a local path.
     v1::ModelInfo model;
     model.set_id(entry.id);
     model.set_name(entry.name);

--- a/src/catalog/model_ref.cpp
+++ b/src/catalog/model_ref.cpp
@@ -159,8 +159,41 @@ void infer_local_kind(const std::string &path,
     if (name.ends_with(".mlpackage") || name.ends_with(".mlmodelc")) {
       *framework = runanywhere::v1::INFERENCE_FRAMEWORK_COREML;
       *format = runanywhere::v1::MODEL_FORMAT_MLPACKAGE;
-      break;
+      return;
     }
+  }
+  // QHexRT HNPU bundles: Hexagon arch folder (v75/v79/v81), a context.bin, or
+  // a top-level non-aux .json next to QNN binaries. `_HNPU` is the published
+  // repo suffix; honor it so `rcli run --engine qhexrt <dir>` is not required.
+  const std::string leaf = p.filename().string();
+  auto looks_qnn = [&]() -> bool {
+    if (leaf.find("_HNPU") != std::string::npos || leaf.find("-npu") != std::string::npos) {
+      return true;
+    }
+    std::error_code inner_ec;
+    bool saw_json = false;
+    bool saw_bin = false;
+    for (const auto &entry : std::filesystem::directory_iterator(p, inner_ec)) {
+      if (inner_ec) {
+        break;
+      }
+      const std::string name = entry.path().filename().string();
+      if (name == "v75" || name == "v79" || name == "v81" || name == "context.bin") {
+        return true;
+      }
+      if (name.ends_with(".json") && name != "tokenizer.json" && name != "config.json" &&
+          name != "tokenizer_config.json" && name != "generation_config.json") {
+        saw_json = true;
+      }
+      if (name.ends_with(".bin") || name.ends_with(".raw")) {
+        saw_bin = true;
+      }
+    }
+    return saw_json && saw_bin;
+  };
+  if (looks_qnn()) {
+    *framework = runanywhere::v1::INFERENCE_FRAMEWORK_QHEXRT;
+    *format = runanywhere::v1::MODEL_FORMAT_QNN_CONTEXT;
   }
 }
 

--- a/src/commands/engine_options.cpp
+++ b/src/commands/engine_options.cpp
@@ -45,6 +45,11 @@ bool parse_engine_hint(const std::string& engine,
         *out_framework = runanywhere::v1::INFERENCE_FRAMEWORK_SHERPA;
         return true;
     }
+    if (normalized == "qhexrt" || normalized == "qnn" || normalized == "npu" ||
+        normalized == "hexagon" || normalized == "hexagon-npu") {
+        *out_framework = runanywhere::v1::INFERENCE_FRAMEWORK_QHEXRT;
+        return true;
+    }
     if (error) {
         *error = "unsupported engine '" + engine + "'";
     }


### PR DESCRIPTION
## Summary
- Expand `scripts/e2e.sh` so it asserts linked engines (nm/strings), honors kit `HAS_LLAMACPP` (Windows ARM64 public kits have none), and adds opt-in model round-trips for MLX / NeuRT / QHexRT.
- Register Hexagon NPU catalog ids, infer QNN-context local paths, and accept `--engine qhexrt`.
- Link `libcurl.lib` from the kit when present so Windows ARM64 overlay builds resolve curl symbols.

## Test plan
- [x] Public `rcli` 0.5.1 macOS bottle: backends mlx+llamacpp+onnx+sherpa; `mlx-qwen3` generate; MLX TTS; Sherpa STT; Silero VAD
- [x] Overlay-built macOS `rcli`: backends include **neurt**; `image generate` SD1.5 → 512×512 PNG
- [x] Published Windows x64 bottle: llamacpp+onnx+sherpa e2e
- [x] Windows ARM64 overlay `rcli.exe`: **qhexrt** registered; LFM2.5 230M HNPU generate (TTFT 30 ms) with QAIRT 2.48 + `ADSP_LIBRARY_PATH`
- [ ] CI macos-26 / windows-2022 still green without overlays


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Qualcomm Hexagon NPU (QHexRT) engine aliases, including `qhexrt`, `qnn`, and `hexagon`.
  * Added four QHexRT-compatible model catalog entries and local bundle detection.
  * Added support for local model paths and image-generation test flows.
  * Added binary checks to verify enabled backend support.
* **Bug Fixes**
  * Improved Windows runtime linking when the required networking library is available.
  * Updated the Stable Diffusion model catalog to use the compiled package.
* **Documentation**
  * Expanded backend configuration, device validation, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->