### PR TITLE
chore: release 0.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.24)
-project(rcli VERSION 0.5.1 LANGUAGES C CXX)
+project(rcli VERSION 0.5.2 LANGUAGES C CXX)
 
 # Product version is independent of the SDK kit pin in cmake/sdk-pin.cmake.
 # scripts/package-rcli.sh and the release workflow stamp this into Formula/rcli.rb.


### PR DESCRIPTION
Bumps `CMakeLists.txt`'s `PROJECT_VERSION` to match the release this cuts (0.5.1 -> 0.5.2), which contains the pinned-SDK-kit bump to v0.20.31 (#44) and the overlay-copy glob fix (#45) — together resolving `qwen3.8-27b-1bit-npu`'s `HostOpFailed` regression, confirmed on real Snapdragon X2 Elite hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to 0.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->