### PR TITLE
Harden release archives and installers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  distribution:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate distribution tooling
+        run: |
+          set -euo pipefail
+          python3 tests/test_release_assets.py
+          python3 -m py_compile scripts/verify-release-assets.py scripts/stamp-formula.py
+          bash -n install.sh scripts/package-rcli.sh scripts/update-tap.sh
+          ruby -c Formula/rcli.rb
+
   macos:
     # SDK Package.swift is swift-tools-version 6.2 (Xcode 26). macos-15 is
     # Xcode 16.4 / Swift 6.1; macos-14 is Xcode 15 / Swift 5.10.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
           VERSION="${RCLI_VERSION#v}"
           RCLI_VERSION="${VERSION}" RCLI_SDK_KIT="${GITHUB_WORKSPACE}/kit" \
             bash scripts/package-rcli.sh build macos-arm64
+          python3 scripts/verify-release-assets.py \
+            "dist/rcli-${VERSION}-macos-arm64.tar.gz" \
+            "dist/rcli-${VERSION}-macos-arm64.tar.gz.sha256"
       - uses: actions/upload-artifact@v4
         with:
           name: rcli-macos-arm64
@@ -99,6 +102,9 @@ jobs:
           $kit = Join-Path $env:GITHUB_WORKSPACE "kit"
           $env:RCLI_SDK_KIT = $kit
           & powershell -File scripts/package-rcli-windows.ps1 -BuildDir build -Version $ver -KitDir $kit
+          python scripts/verify-release-assets.py `
+            "dist/rcli-$ver-windows-x86_64.zip" `
+            "dist/rcli-$ver-windows-x86_64.zip.sha256"
       # Zip only. onnxruntime.dll lives next to rcli.exe *inside* the archive;
       # uploading the loose DLL/exe made them look like first-class release assets.
       - uses: actions/upload-artifact@v4
@@ -120,15 +126,32 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-      - name: Stamp formula (best effort)
+      - name: Verify release archives
         run: |
           set -euo pipefail
           VERSION="${RCLI_VERSION#v}"
-          mac=$(ls artifacts/rcli-${VERSION}-macos-arm64.tar.gz.sha256 2>/dev/null || true)
-          if [[ -n "$mac" && -f scripts/stamp-formula.py ]]; then
-            digest=$(awk '{print $1}' "$mac")
-            python3 scripts/stamp-formula.py "$VERSION" "macos-arm64=${digest}" || true
-          fi
+          python3 scripts/verify-release-assets.py \
+            "artifacts/rcli-${VERSION}-macos-arm64.tar.gz" \
+            "artifacts/rcli-${VERSION}-macos-arm64.tar.gz.sha256"
+          python3 scripts/verify-release-assets.py \
+            "artifacts/rcli-${VERSION}-windows-x86_64.zip" \
+            "artifacts/rcli-${VERSION}-windows-x86_64.zip.sha256"
+      - name: Generate Homebrew formula update
+        run: |
+          set -euo pipefail
+          VERSION="${RCLI_VERSION#v}"
+          sidecar="artifacts/rcli-${VERSION}-macos-arm64.tar.gz.sha256"
+          digest=$(awk 'NF == 2 { print $1 }' "$sidecar")
+          [[ "$digest" =~ ^[0-9a-f]{64}$ ]]
+          python3 scripts/stamp-formula.py "$VERSION" "macos-arm64=${digest}"
+          ruby -c Formula/rcli.rb
+          mkdir -p release-metadata
+          cp Formula/rcli.rb release-metadata/rcli.rb
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rcli-homebrew-formula
+          path: release-metadata/rcli.rb
+          if-no-files-found: error
       - name: Create the release
         uses: softprops/action-gh-release@v2
         with:

--- a/Formula/rcli.rb
+++ b/Formula/rcli.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 class Rcli < Formula
   desc "Run language, speech and image models on your own machine"
   homepage "https://github.com/RunanywhereAI/RCLI"
+  version "0.5.2"
   license "MIT"
-  version "0.5.1"
 
-    # 0.5.1 is the kit-consumer CMake bottle. macOS arm64 ships the Swift MLX host
+  # macOS arm64 ships the Swift MLX host
   # (llama.cpp + ONNX + Sherpa + MLX). Linux is not in this cut.
   on_macos do
     on_arm do
-      url "https://github.com/RunanywhereAI/RCLI/releases/download/v0.5.0/rcli-0.5.0-macos-arm64.tar.gz"
-      sha256 "aa524eef31405d99c1fda4b90c3b1f3e8f74302fe209ba7fe81b343a1f92a266"
+      url "https://github.com/RunanywhereAI/RCLI/releases/download/v0.5.2/rcli-0.5.2-macos-arm64.tar.gz"
+      sha256 "fc16e5e3fdef1e62b7d05d569ce8a69cc86cdd2b880d5983c495a5e240384430"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ irm https://raw.githubusercontent.com/RunanywhereAI/RCLI/main/install.ps1 | iex
 
 ### Linux (x86_64)
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/RunanywhereAI/RCLI/main/install.sh | sh
-```
+No Linux release asset is currently published. Use the source build below;
+`install.sh` intentionally fails instead of claiming that an unavailable bottle
+was installed.
 
 ## Get started
 
@@ -79,10 +79,10 @@ rcli image generate --engine neurt --prompt "a red cube" --out out.png
 
 | Backend | macOS Apple Silicon | Windows x64 | Windows ARM64 | Linux x64 |
 |---|---|---|---|---|
-| [llama.cpp](https://github.com/ggml-org/llama.cpp) | public bottle | public bottle | — | public bottle |
+| [llama.cpp](https://github.com/ggml-org/llama.cpp) | public bottle | public bottle | — | source build only |
 | [MLX](https://github.com/ml-explore/mlx) (Apple GPU) | public bottle (product `rcli`, not `rcli-cxx`) | — | — | — |
-| [Sherpa-ONNX](https://github.com/k2-fsa/sherpa-onnx) | public bottle | public bottle | — | public bottle |
-| [ONNX Runtime](https://onnxruntime.ai) | public bottle | public bottle | — | public bottle |
+| [Sherpa-ONNX](https://github.com/k2-fsa/sherpa-onnx) | public bottle | public bottle | — | source build only |
+| [ONNX Runtime](https://onnxruntime.ai) | public bottle | public bottle | — | source build only |
 | NeuRT (Apple Neural Engine; Core ML is the format) | **overlay** rebuild | — | — | — |
 | QHexRT (Qualcomm Hexagon NPU) | — | — | **overlay** rebuild | — |
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -45,52 +45,62 @@ llm           ok        HTTP 200    1           1         0
 - `auth login` runs the authenticated handshake (`/api/v1/auth/sdk/authenticate` → `/api/v1/devices/register` → model assignments). Production only.
 - `telemetry emit|blast` drive the real commons telemetry pipeline to `/api/v2/sdk/telemetry/{modality}`. Development is keyless (no JWT). Production logs in first. Modalities: `llm stt tts vlm rag imagegen embeddings vad voice lora model system`. Exit is non-zero when any POST fails or any tracked event never reached the backend.
 
-## macOS distribution signing
+## Published asset contract
 
-`release.yml` builds the combined Swift/C++ host from the same Apple artifacts as the SDK release, imports a Developer ID Application certificate into an ephemeral keychain, signs the executable and compatibility libraries with the hardened runtime and secure timestamp, notarizes a DMG, staples and validates its ticket, then deletes the temporary keychain and credential files.
+The current `release.yml` publishes two archives and matching SHA-256
+sidecars. It does not build or advertise a Linux release:
 
-The repository stores no signing material. Configure the Developer ID secrets and one complete notarization credential set before creating a release tag:
+| Platform | Asset | Required archive root |
+|---|---|---|
+| macOS Apple Silicon | `rcli-X.Y.Z-macos-arm64.tar.gz` | `rcli-macos-arm64/` |
+| Windows x86_64 | `rcli-X.Y.Z-windows-x86_64.zip` | `rcli-windows-x86_64/` |
 
-- `RCLI_DEVELOPER_ID_CERT_P12_BASE64`
-- `RCLI_DEVELOPER_ID_CERT_PASSWORD`
+Each root contains a non-empty `README.md` and `bin/rcli` or `bin/rcli.exe`.
+Windows DLLs stay beside `bin/rcli.exe`. The macOS archive contains the Swift
+MLX host and its resource bundles. `scripts/verify-release-assets.py` verifies
+the sidecar digest, filename, single-root layout, required files, executable
+mode, duplicate paths, traversal, links, and expansion limits. Packaging jobs
+and the publish job all run it before a release is created.
 
-Preferred App Store Connect API-key notarization:
+## Signing reality and production gates
 
-- `RCLI_NOTARY_API_KEY_P8_BASE64`
-- `RCLI_NOTARY_KEY_ID`
-- `RCLI_NOTARY_ISSUER_ID`
+Credential-free macOS packaging is ad-hoc signed. `scripts/package-rcli.sh`
+checks that signature and can sign with an already-installed Developer ID
+identity via `RCLI_CODESIGN_IDENTITY` and optional `RCLI_CODESIGN_KEYCHAIN`.
+Set `RCLI_REQUIRE_DEVELOPER_ID=1` to make ad-hoc signing an error. The GitHub
+workflow does **not** currently import an identity, notarize an archive, create
+a DMG, or staple a ticket.
 
-Apple ID fallback notarization:
+The Windows workflow currently packages an unsigned executable. It does not
+import a PFX, Authenticode-sign, or validate a certificate chain.
 
-- `RCLI_NOTARY_APPLE_ID`
-- `RCLI_NOTARY_APP_SPECIFIC_PASSWORD`
-- `RCLI_NOTARY_TEAM_ID`
+Therefore these are launch gates, not completed workflow features:
 
-When both notarization sets are complete, the workflow uses the App Store Connect API key. The Apple ID fallback stores its run-scoped notarytool profile only in the same ephemeral keychain as the imported Developer ID identity, passes that keychain explicitly during submission, and deletes it after the package step.
+- import a Developer ID Application identity into an ephemeral keychain, sign
+  nested code and the host with hardened runtime/timestamp, notarize the exact
+  distributed artifact, and validate Gatekeeper acceptance;
+- Authenticode-sign `rcli.exe` and DLLs as required, then validate signatures on
+  a clean Windows host;
+- provide the signing/notarization credentials through protected release
+  environments and keep pull-request jobs credential-free.
 
-For a local or external release runner, `scripts/package-rcli.sh` accepts an already-available identity through `RCLI_CODESIGN_IDENTITY` (and optionally `RCLI_CODESIGN_KEYCHAIN`). Set `RCLI_MACOS_NOTARIZE=1` and authenticate notarytool either with `RCLI_NOTARYTOOL_PROFILE` (plus `RCLI_NOTARYTOOL_KEYCHAIN` for a profile in a non-default keychain) or the API-key path, key ID, and issuer ID variables documented at the top of that script. The normal credential-free packaging path remains ad-hoc signed for pull-request smoke.
-
-## Windows distribution signing
-
-The release workflow Authenticode-signs `rcli.exe`, validates the resulting signature, and only then creates the Windows ZIP. Configure these repository secrets before creating a release tag:
-
-- `RCLI_WINDOWS_CODESIGN_PFX_BASE64`
-- `RCLI_WINDOWS_CODESIGN_PFX_PASSWORD`
-
-Pull-request builds remain credential-free and validate the same unsigned binary/package layout before the protected release job performs signing.
+Do not describe an asset as notarized or Authenticode-signed until the workflow
+and the downloaded release prove it. Useful post-download checks are
+`codesign -dv --verbose=4`, `codesign --verify --strict`, and `spctl --assess`
+on macOS, and `Get-AuthenticodeSignature` on Windows.
 
 ## CI and release workflow
 
-- `pr-build.yml` builds macOS, Linux, and Windows rcli targets and runs unit, backend-registration, relocatable-package, and modelless smoke checks.
-- `release.yml` requires all three rcli packages before publishing the GitHub Release.
-- macOS GitHub Release assets include a Developer ID signed, notarized, and stapled disk image alongside the tarball.
+- `ci.yml` builds and tests macOS and Windows. Its distribution job also tests
+  archive verification, shell syntax, formula syntax, and stamping code.
+- `release.yml` builds macOS and Windows, runs product e2e, packages, verifies
+  each archive twice, then publishes the two archives and sidecars.
+- The publish job generates a `rcli-homebrew-formula` workflow artifact from
+  the verified macOS checksum. It does not pretend that an ephemeral checkout
+  updated a default branch.
 
-Published release assets are platform-specific:
-
-| Platform | Asset | Included engines |
-|---|---|---|
-| macOS Apple Silicon | `rcli-macos-arm64-vX.Y.Z.tar.gz` and signed/notarized DMG | llama.cpp + MLX + Sherpa-ONNX + ONNX Runtime + CoreML |
-| Linux x86_64 | `rcli-linux-x86_64-vX.Y.Z.tar.gz` | llama.cpp + Sherpa-ONNX + ONNX Runtime |
-| Windows x86_64 | `rcli-windows-x86_64-vX.Y.Z.zip` | llama.cpp + Sherpa-ONNX + ONNX Runtime |
-
-The tagged macOS release packages the `RunAnywhereMLXCLI` product as `bin/rcli` together with `mlx.metallib`, its SwiftPM resource bundles, and any deployment-target Swift compatibility libraries. The CMake `rcli` binary remains the fast, credential-free pull-request smoke target; it registers llama.cpp and exposes the dual catalog but cannot execute MLX without the Swift callbacks.
+Homebrew still needs one ownership decision: `install.sh` taps the RCLI repo as
+`runanywhereai/rcli`, while the historical update script targeted a separate
+`homebrew-tap` repo. Until one is declared canonical, pass `RCLI_TAP_REPO`
+explicitly to `scripts/update-tap.sh` and apply the generated formula to the
+same tap users install from.

--- a/install.ps1
+++ b/install.ps1
@@ -61,6 +61,9 @@ if (-not $Asset) {
     Fail "v$Version does not publish $AssetName. Open an issue at https://github.com/$Repo/issues"
 }
 $ShaAsset = $Release.assets | Where-Object { $_.name -eq "$AssetName.sha256" } | Select-Object -First 1
+if (-not $ShaAsset) {
+    Fail "v$Version does not publish $AssetName.sha256. Refusing an unverified download."
+}
 
 $Temp = Join-Path ([IO.Path]::GetTempPath()) ('rcli-' + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $Temp -Force | Out-Null
@@ -73,40 +76,67 @@ try {
         Fail "Could not download $($Asset.browser_download_url)"
     }
 
-    if ($ShaAsset) {
-        # Through a file rather than straight into a variable: the asset is
-        # served as octet-stream and the web cmdlets hand back bytes for that,
-        # not the line of text this needs.
-        $ShaFile = Join-Path $Temp $ShaAsset.name
-        Invoke-WebRequest -Uri $ShaAsset.browser_download_url -OutFile $ShaFile
-        # Both lowercased rather than relying on -ne being case-insensitive:
-        # Get-FileHash returns uppercase and the sidecar is written lowercase,
-        # so the comparison only looks wrong until you know that rule.
-        $Expected = ((Get-Content -Raw -LiteralPath $ShaFile) -split '\s+')[0].ToLowerInvariant()
-        $Actual = (Get-FileHash -LiteralPath $Zip -Algorithm SHA256).Hash.ToLowerInvariant()
-        if ($Actual -ne $Expected) {
-            Fail "Checksum mismatch on $AssetName. Expected $Expected, got $Actual. Do not use this download."
-        }
-        Write-Ok 'Checksum verified'
-    } else {
-        Write-Warn "The release publishes no $AssetName.sha256, so the download could not be verified."
+    # Through a file rather than straight into a variable: the asset is served
+    # as octet-stream and the web cmdlets hand back bytes rather than text.
+    $ShaFile = Join-Path $Temp $ShaAsset.name
+    Invoke-WebRequest -Uri $ShaAsset.browser_download_url -OutFile $ShaFile
+    $ShaLine = (Get-Content -Raw -LiteralPath $ShaFile).Trim()
+    if ($ShaLine -notmatch '^([0-9A-Fa-f]{64})\s+\*?([^\r\n]+)$') {
+        Fail "$($ShaAsset.name) is not a valid SHA-256 sidecar."
     }
+    $Expected = $Matches[1].ToLowerInvariant()
+    $ListedAsset = $Matches[2].Trim()
+    if ($ListedAsset -ne $AssetName) {
+        Fail "$($ShaAsset.name) names $ListedAsset instead of $AssetName."
+    }
+    $Actual = (Get-FileHash -LiteralPath $Zip -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($Actual -ne $Expected) {
+        Fail "Checksum mismatch on $AssetName. Expected $Expected, got $Actual. Do not use this download."
+    }
+    Write-Ok 'Checksum verified'
 
     Write-Info "Installing RCLI v$Version to $InstallDir..."
     Expand-Archive -LiteralPath $Zip -DestinationPath $Temp -Force
     $Stem = [IO.Path]::GetFileNameWithoutExtension($AssetName)
-    $Unpacked = Join-Path $Temp "$Stem\libexec"
+    $Unpacked = Join-Path $Temp "$Stem\bin"
     if (-not (Test-Path -LiteralPath $Unpacked)) {
         Fail "$AssetName does not have the layout this installer expects. Open an issue at https://github.com/$Repo/issues"
     }
 
-    # libexec is the package's own layout, the one the Homebrew formula installs
-    # and symlinks a bin/rcli at. Nothing to symlink here, so its contents land
-    # directly in the install directory and that directory goes on PATH: rcli.exe
-    # finds its DLLs by being in the same folder as them.
-    Remove-Item -LiteralPath $InstallDir -Recurse -Force -ErrorAction SilentlyContinue
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-    Copy-Item -Path (Join-Path $Unpacked '*') -Destination $InstallDir -Recurse -Force
+    # Validate a complete candidate before replacing a working installation.
+    # rcli.exe and its DLLs stay together exactly as they are in archive bin/.
+    $Candidate = Join-Path $Temp 'install-candidate'
+    New-Item -ItemType Directory -Path $Candidate -Force | Out-Null
+    Copy-Item -Path (Join-Path $Unpacked '*') -Destination $Candidate -Recurse -Force
+    $CandidateExe = Join-Path $Candidate 'rcli.exe'
+    if (-not (Test-Path -LiteralPath $CandidateExe)) {
+        Fail "$AssetName is missing bin\rcli.exe."
+    }
+    $VersionOutput = @(& $CandidateExe --version 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        Fail 'The downloaded rcli.exe does not run; the existing installation was left unchanged.'
+    }
+    $EscapedVersion = [Regex]::Escape($Version)
+    if (($VersionOutput -join "`n") -notmatch "(?m)^rcli\s+$EscapedVersion(?:\s|$)") {
+        Fail "The downloaded executable does not report RCLI v$Version; the existing installation was left unchanged."
+    }
+
+    $InstallParent = Split-Path $InstallDir -Parent
+    New-Item -ItemType Directory -Path $InstallParent -Force | Out-Null
+    $Backup = "$InstallDir.previous"
+    Remove-Item -LiteralPath $Backup -Recurse -Force -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $InstallDir) {
+        Move-Item -LiteralPath $InstallDir -Destination $Backup
+    }
+    try {
+        Move-Item -LiteralPath $Candidate -Destination $InstallDir
+    } catch {
+        if (Test-Path -LiteralPath $Backup) {
+            Move-Item -LiteralPath $Backup -Destination $InstallDir
+        }
+        throw
+    }
+    Remove-Item -LiteralPath $Backup -Recurse -Force -ErrorAction SilentlyContinue
 } finally {
     Remove-Item -LiteralPath $Temp -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/install.sh
+++ b/install.sh
@@ -24,11 +24,10 @@ os=$(uname -s)
 arch=$(uname -m)
 case "${os}/${arch}" in
     # MLX is Metal and NeuRT is the Apple Neural Engine, so an Intel Mac would
-    # get neither and there is no build for it. Linux is x86-64 only for now.
+    # get neither and there is no build for it. No Linux release is published.
     Darwin/arm64)  ;;
-    Linux/x86_64)  ;;
     Darwin/*)      fail "RCLI needs an Apple Silicon Mac. Detected: ${arch}" ;;
-    Linux/*)       fail "RCLI on Linux is x86-64 only. Detected: ${arch}" ;;
+    Linux/*)       fail "RCLI does not currently publish a Linux binary. Build from source: https://github.com/${REPO}#build-from-source" ;;
     *)             fail "RCLI has no build for ${os}. On Windows, use install.ps1." ;;
 esac
 
@@ -75,6 +74,13 @@ fi
 
 if ! command -v rcli &>/dev/null; then
     fail "Installation failed. rcli not found in PATH."
+fi
+
+installed_version="$(rcli --version 2>/dev/null \
+    | sed -nE 's/^rcli ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' \
+    | head -1)"
+if [[ "${installed_version}" != "${VERSION}" ]]; then
+    fail "Homebrew installed RCLI v${installed_version:-unknown}, but GitHub's latest release is v${VERSION}. The tap formula must be updated before this installer can claim success."
 fi
 
 ok "RCLI v${VERSION} installed successfully"

--- a/scripts/package-rcli.sh
+++ b/scripts/package-rcli.sh
@@ -5,6 +5,8 @@
 #
 #   platform-tag: macos-arm64 | linux-x86_64
 #   version:      $RCLI_VERSION, else project(rcli VERSION …)
+#   macOS signing: $RCLI_CODESIGN_IDENTITY, optional $RCLI_CODESIGN_KEYCHAIN
+#                  Set $RCLI_REQUIRE_DEVELOPER_ID=1 to reject ad-hoc signing.
 #
 # Layout:
 #   rcli-<platform>/bin/rcli
@@ -95,7 +97,26 @@ case "${PLATFORM}" in
         install_name_tool -id "@rpath/$(basename "${lib}")" "${lib}" 2>/dev/null || true
       done
     fi
-    codesign --force -s - "${STAGE}/bin/rcli" 2>/dev/null || true
+    sign_identity="${RCLI_CODESIGN_IDENTITY:--}"
+    if [[ "${RCLI_REQUIRE_DEVELOPER_ID:-0}" == 1 && "${sign_identity}" == - ]]; then
+      echo "error: production packaging requires RCLI_CODESIGN_IDENTITY" >&2
+      exit 1
+    fi
+    sign_args=(--force --sign "${sign_identity}")
+    if [[ "${sign_identity}" != - ]]; then
+      sign_args+=(--options runtime --timestamp)
+    fi
+    if [[ -n "${RCLI_CODESIGN_KEYCHAIN:-}" ]]; then
+      sign_args+=(--keychain "${RCLI_CODESIGN_KEYCHAIN}")
+    fi
+    shopt -s nullglob
+    for lib in "${STAGE}/lib/"*.dylib; do
+      codesign "${sign_args[@]}" "${lib}"
+      codesign --verify --strict "${lib}"
+    done
+    shopt -u nullglob
+    codesign "${sign_args[@]}" "${STAGE}/bin/rcli"
+    codesign --verify --strict "${STAGE}/bin/rcli"
     ;;
   linux-*)
     if command -v patchelf >/dev/null; then
@@ -108,7 +129,9 @@ esac
 
 mkdir -p "${DIST}"
 rm -f "${TARBALL}" "${TARBALL}.sha256"
-tar -czf "${TARBALL}" -C "${STAGE_ROOT}" "rcli-${PLATFORM}"
+# macOS tar otherwise serializes Finder metadata as `._*` AppleDouble roots,
+# breaking the single-root archive contract and surprising non-macOS clients.
+COPYFILE_DISABLE=1 tar -czf "${TARBALL}" -C "${STAGE_ROOT}" "rcli-${PLATFORM}"
 (cd "${DIST}" && shasum -a 256 "$(basename "${TARBALL}")" > "$(basename "${TARBALL}").sha256")
 echo "Packaged ${TARBALL}"
 tar -tzf "${TARBALL}" | head -20

--- a/scripts/stamp-formula.py
+++ b/scripts/stamp-formula.py
@@ -6,9 +6,9 @@
     stamp-formula.py 0.4.0 macos-arm64=abc... linux-x86_64=def...
 
 Homebrew reads a tap's formula from the default branch rather than from the tag,
-so the formula on main has to name the archives a release just published. This
-was a manual step and the sha256 went stale as a matter of course; the release
-workflow calls this instead.
+so a release alone cannot update what users install. The release workflow calls
+this to produce a reviewed formula artifact; applying that artifact to the
+canonical tap remains an explicit post-release step.
 
 The formula carries one url/sha256 pair per platform inside on_macos/on_linux
 blocks. Each pair is found by the platform slug in its url, and the sha256

--- a/scripts/update-tap.sh
+++ b/scripts/update-tap.sh
@@ -8,7 +8,7 @@
 #   ./scripts/update-tap.sh 0.5.0
 #
 # Environment:
-#   RCLI_TAP_REPO   Tap git remote (default git@github.com:RunanywhereAI/homebrew-tap.git)
+#   RCLI_TAP_REPO   Tap git remote to update (required unless DRY_RUN=1)
 #   RCLI_TAP_DIR    Existing tap checkout to reuse (default: fresh temp clone)
 #   DRY_RUN=1       Render + print, do not commit/push
 # =============================================================================
@@ -22,7 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 FORMULA="${CLI_ROOT}/Formula/rcli.rb"
 RELEASE_BASE="https://github.com/RunanywhereAI/RCLI/releases/download/v${VERSION}"
-TAP_REPO="${RCLI_TAP_REPO:-git@github.com:RunanywhereAI/homebrew-tap.git}"
+TAP_REPO="${RCLI_TAP_REPO:-}"
 
 fetch_sha() {
     local asset="$1"
@@ -53,6 +53,11 @@ if [[ "${DRY_RUN:-0}" == "1" ]]; then
     exit 0
 fi
 
+if [[ -z "${TAP_REPO}" ]]; then
+    echo "ERROR: set RCLI_TAP_REPO explicitly; the canonical RCLI vs homebrew-tap repository has not been decided." >&2
+    exit 1
+fi
+
 TAP_DIR="${RCLI_TAP_DIR:-}"
 if [[ -z "${TAP_DIR}" ]]; then
     TAP_DIR="$(mktemp -d)/homebrew-tap"
@@ -65,4 +70,4 @@ git -C "${TAP_DIR}" add Formula/rcli.rb
 git -C "${TAP_DIR}" commit -m "rcli ${VERSION}"
 git -C "${TAP_DIR}" push
 
-echo "Tap updated: brew install runanywhereai/tap/rcli"
+echo "Tap formula updated in ${TAP_REPO}"

--- a/scripts/verify-release-assets.py
+++ b/scripts/verify-release-assets.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for an RCLI release archive and SHA-256 sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import re
+import stat
+import tarfile
+import zipfile
+
+
+ASSET = re.compile(
+    r"^rcli-(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-"
+    r"(?P<platform>macos-arm64|windows-x86_64)\.(?P<suffix>tar\.gz|zip)$"
+)
+MAX_MEMBERS = 100_000
+MAX_UNCOMPRESSED_BYTES = 4 * 1024 * 1024 * 1024
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def normalized_member(name: str) -> str:
+    normalized = name.replace("\\", "/").rstrip("/")
+    path = pathlib.PurePosixPath(normalized)
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or path.is_absolute()
+        or ".." in path.parts
+        or not path.parts
+        or path.parts[0].endswith(":")
+    ):
+        raise VerificationError(f"unsafe archive member: {name!r}")
+    return normalized
+
+
+def validate_members(
+    members: list[tuple[str, int, bool, bool]], expected_root: str, executable: str
+) -> None:
+    if len(members) > MAX_MEMBERS:
+        raise VerificationError(f"archive has more than {MAX_MEMBERS} members")
+
+    seen: set[str] = set()
+    roots: set[str] = set()
+    sizes: dict[str, int] = {}
+    executable_bits: dict[str, bool] = {}
+    total = 0
+    for original, size, is_regular, is_executable in members:
+        name = normalized_member(original)
+        if name in seen:
+            raise VerificationError(f"duplicate archive member after normalization: {name}")
+        seen.add(name)
+        roots.add(pathlib.PurePosixPath(name).parts[0])
+        if size < 0:
+            raise VerificationError(f"negative member size: {name}")
+        total += size
+        if total > MAX_UNCOMPRESSED_BYTES:
+            raise VerificationError("archive expands beyond the 4 GiB safety limit")
+        if is_regular:
+            sizes[name] = size
+            executable_bits[name] = is_executable
+
+    if roots != {expected_root}:
+        raise VerificationError(
+            f"archive root is {sorted(roots)!r}; expected exactly {expected_root!r}"
+        )
+    readme = f"{expected_root}/README.md"
+    binary = f"{expected_root}/bin/{executable}"
+    if sizes.get(readme, 0) <= 0:
+        raise VerificationError(f"archive is missing non-empty {readme}")
+    if sizes.get(binary, 0) <= 0:
+        raise VerificationError(f"archive is missing non-empty {binary}")
+    if executable == "rcli" and not executable_bits.get(binary, False):
+        raise VerificationError(f"{binary} has no executable mode bit")
+
+
+def verify_tar(archive: pathlib.Path, expected_root: str) -> None:
+    members: list[tuple[str, int, bool, bool]] = []
+    try:
+        with tarfile.open(archive, "r:gz") as bundle:
+            for member in bundle.getmembers():
+                if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+                    raise VerificationError(
+                        f"links and special files are not allowed: {member.name!r}"
+                    )
+                members.append(
+                    (member.name, member.size, member.isfile(), bool(member.mode & 0o111))
+                )
+    except (tarfile.TarError, OSError) as exc:
+        raise VerificationError(f"could not read tar archive: {exc}") from exc
+    validate_members(members, expected_root, "rcli")
+
+
+def verify_zip(archive: pathlib.Path, expected_root: str) -> None:
+    members: list[tuple[str, int, bool, bool]] = []
+    try:
+        with zipfile.ZipFile(archive) as bundle:
+            for member in bundle.infolist():
+                unix_mode = member.external_attr >> 16
+                if stat.S_IFMT(unix_mode) == stat.S_IFLNK:
+                    raise VerificationError(f"symbolic links are not allowed: {member.filename!r}")
+                is_directory = member.is_dir() or member.filename.endswith(("/", "\\"))
+                members.append(
+                    (member.filename, member.file_size, not is_directory, bool(unix_mode & 0o111))
+                )
+    except (zipfile.BadZipFile, OSError) as exc:
+        raise VerificationError(f"could not read zip archive: {exc}") from exc
+    validate_members(members, expected_root, "rcli.exe")
+
+
+def verify_sidecar(archive: pathlib.Path, sidecar: pathlib.Path) -> None:
+    try:
+        line = sidecar.read_text(encoding="ascii").strip()
+    except (OSError, UnicodeError) as exc:
+        raise VerificationError(f"could not read checksum sidecar: {exc}") from exc
+    match = re.fullmatch(r"([0-9A-Fa-f]{64})[ \t]+\*?([^\r\n]+)", line)
+    if match is None:
+        raise VerificationError("checksum sidecar must contain one SHA-256 and filename")
+    if match.group(2).strip() != archive.name:
+        raise VerificationError(
+            f"checksum sidecar names {match.group(2).strip()!r}, expected {archive.name!r}"
+        )
+    expected = match.group(1).lower()
+    digest = hashlib.sha256()
+    try:
+        with archive.open("rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as exc:
+        raise VerificationError(f"could not hash archive: {exc}") from exc
+    actual = digest.hexdigest()
+    if actual != expected:
+        raise VerificationError(f"checksum mismatch: expected {expected}, got {actual}")
+
+
+def verify(archive: pathlib.Path, sidecar: pathlib.Path) -> None:
+    match = ASSET.fullmatch(archive.name)
+    if match is None:
+        raise VerificationError(f"unsupported release asset name: {archive.name!r}")
+    if not archive.is_file() or archive.stat().st_size == 0:
+        raise VerificationError(f"release asset is missing or empty: {archive}")
+    verify_sidecar(archive, sidecar)
+    platform = match.group("platform")
+    expected_root = f"rcli-{platform}"
+    if match.group("suffix") == "tar.gz":
+        verify_tar(archive, expected_root)
+    else:
+        verify_zip(archive, expected_root)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=pathlib.Path)
+    parser.add_argument("sidecar", type=pathlib.Path)
+    args = parser.parse_args()
+    try:
+        verify(args.archive, args.sidecar)
+    except VerificationError as exc:
+        parser.error(str(exc))
+    print(f"verified {args.archive.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_assets.py
+++ b/tests/test_release_assets.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Hermetic tests for scripts/verify-release-assets.py."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import pathlib
+import stat
+import tarfile
+import tempfile
+import unittest
+import zipfile
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "verify_release_assets", ROOT / "scripts" / "verify-release-assets.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+VERIFY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY)
+
+
+class ReleaseAssetTests(unittest.TestCase):
+    def sidecar(self, archive: pathlib.Path, *, filename: str | None = None) -> pathlib.Path:
+        digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+        sidecar = archive.with_name(archive.name + ".sha256")
+        sidecar.write_text(f"{digest}  {filename or archive.name}\n", encoding="ascii")
+        return sidecar
+
+    def add_tar_file(self, bundle: tarfile.TarFile, name: str, contents: bytes, mode: int) -> None:
+        member = tarfile.TarInfo(name)
+        member.size = len(contents)
+        member.mode = mode
+        bundle.addfile(member, io.BytesIO(contents))
+
+    def test_valid_macos_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "rcli-1.2.3-macos-arm64.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                self.add_tar_file(bundle, "rcli-macos-arm64/README.md", b"readme", 0o644)
+                self.add_tar_file(bundle, "rcli-macos-arm64/bin/rcli", b"binary", 0o755)
+            VERIFY.verify(archive, self.sidecar(archive))
+
+    def test_valid_windows_archive_with_backslash_members(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "rcli-1.2.3-windows-x86_64.zip"
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("rcli-windows-x86_64\\README.md", b"readme")
+                bundle.writestr("rcli-windows-x86_64\\bin\\rcli.exe", b"binary")
+            VERIFY.verify(archive, self.sidecar(archive))
+
+    def test_rejects_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "rcli-1.2.3-windows-x86_64.zip"
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("rcli-windows-x86_64/README.md", b"readme")
+                bundle.writestr("rcli-windows-x86_64/bin/rcli.exe", b"binary")
+                bundle.writestr("rcli-windows-x86_64/../outside", b"bad")
+            with self.assertRaisesRegex(VERIFY.VerificationError, "unsafe archive member"):
+                VERIFY.verify(archive, self.sidecar(archive))
+
+    def test_rejects_wrong_checksum_filename(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "rcli-1.2.3-macos-arm64.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                self.add_tar_file(bundle, "rcli-macos-arm64/README.md", b"readme", 0o644)
+                self.add_tar_file(bundle, "rcli-macos-arm64/bin/rcli", b"binary", 0o755)
+            with self.assertRaisesRegex(VERIFY.VerificationError, "sidecar names"):
+                VERIFY.verify(archive, self.sidecar(archive, filename="different.tar.gz"))
+
+    def test_rejects_non_executable_macos_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "rcli-1.2.3-macos-arm64.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                self.add_tar_file(bundle, "rcli-macos-arm64/README.md", b"readme", 0o644)
+                self.add_tar_file(bundle, "rcli-macos-arm64/bin/rcli", b"binary", 0o644)
+            with self.assertRaisesRegex(VERIFY.VerificationError, "executable mode bit"):
+                VERIFY.verify(archive, self.sidecar(archive))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Hardens RCLI release archives, package-manager metadata, installers, and release checks for the Cloud launch.

## What changed

- Fixes the release asset verifier and updates the Homebrew formula to v0.5.2/SHA.
- Corrects the Windows `bin` installer layout and rollback behavior.
- Makes Linux documentation honest about supported installation paths.
- Handles AppleDouble files and makes macOS codesigning fail closed.
- Adds strict formula-artifact and release-CI checks.

## Validation

- Archive tests: 5/5 passed.
- Live v0.5.2 macOS/Windows downloads and checksums verified.
- macOS packaging smoke/ad-hoc signing passed.
- Shell, Ruby, and YAML syntax checks passed.
- Tap update dry run passed.

## Remaining release gates

- Production Developer ID signing/notarization.
- Windows Authenticode signing.
- Final Homebrew tap ownership/merge coordination.
- PowerShell-specific validation is not available in this environment (`pwsh` missing).

## Non-goals

- No auth flow, inference backend, billing, or NotSglang changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stronger validation for macOS and Windows release archives and checksums.
  - Added safer Windows installation with version verification and rollback support.
  - Added configurable macOS code signing options.

- **Bug Fixes**
  - Installers now fail clearly when assets, checksums, or installed versions are invalid.
  - Linux installation now correctly directs users to build from source.

- **Documentation**
  - Updated platform support, release, signing, and Homebrew guidance.

- **Chores**
  - Updated the Homebrew formula for version 0.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->