### PR TITLE
chore: pin SDK 0.20.33 — NeuRT now serves synthesize

### DIFF
--- a/cmake/sdk-pin.cmake
+++ b/cmake/sdk-pin.cmake
@@ -5,18 +5,17 @@
 # is idl/SCHEMA_LOCK from the SDK). RCLI never runs protoc — a mismatch here
 # means consume a new kit and update this file, not regenerate headers.
 #
-# NOTE for 0.20.32: these stay at 1.1.0 / 377868bf on purpose. The published kit
-# carries those values because release.yml published via `publish_from_run_id`,
-# reusing artifacts built before the monorepo bumped idl/VERSION to 1.1.1 for a
-# COMMENT-ONLY edit. Stripping comments from both revisions of the only changed
-# .proto leaves them byte-identical, so no field, wire value or generated symbol
-# differs — the digest moved because the lock hashes doc text too. Pinning what
-# the kit ACTUALLY carries is the honest value; pinning 1.1.1 here would fail
-# fetch-kit.sh against the very kit it is meant to validate.
-set(RCLI_PINNED_SDK_VERSION "0.20.32")
-set(RCLI_PINNED_IDL_VERSION "1.1.0")
-set(RCLI_PINNED_IDL_SCHEMA_SHA256 "377868bf8e12b327c32978215cafb36c2b1b3157a9be05c7960ac474d55231d2")
+# 0.20.33 moves the IDL pin to 1.1.1 / ec50b7ca, retiring the 0.20.32 note that
+# held it at 1.1.0. That note was correct for its release: 0.20.32 published via
+# `publish_from_run_id`, reusing artifacts built before the monorepo bumped
+# idl/VERSION for a COMMENT-ONLY .proto edit, so the kit genuinely carried the
+# older lock and pinning 1.1.1 would have failed fetch-kit.sh against the very
+# kit it validates. 0.20.33's kits were built after that bump, so these values
+# are read from the shipped SCHEMA_LOCK rather than carried forward.
+set(RCLI_PINNED_SDK_VERSION "0.20.33")
+set(RCLI_PINNED_IDL_VERSION "1.1.1")
+set(RCLI_PINNED_IDL_SCHEMA_SHA256 "ec50b7ca4beff9fa065c5ae1f12dbbc0c996d8b43e64c44bf350ef86a1fa41aa")
 set(RCLI_PINNED_IDL_PROTOC_VERSION "35.1")
-set(RCLI_PINNED_KIT_SHA256_MACOS_ARM64 "e8eaaf0af9177ad1f97b36d88bc3d10130b8858967370943c9b58452934e68ef")
-set(RCLI_PINNED_KIT_SHA256_WINDOWS_X64 "96d96343d7a99fd18df7533b85c864b81dc8ee669b09691d87e707319cae6789")
-set(RCLI_PINNED_KIT_SHA256_WINDOWS_ARM64 "2d753cad5df0d9cfc9d1a5e15b1f41769ba8c30a277a4e291a6a219efbf66700")
+set(RCLI_PINNED_KIT_SHA256_MACOS_ARM64 "e941152803adc297256fc98afa9eecd8f0bb38dfda8bd5b2f3054a67d5e23ec5")
+set(RCLI_PINNED_KIT_SHA256_WINDOWS_X64 "2ed56a8acb860fadd0141407e8669cacd05458e21470a3616e9b7b2e73f8d927")
+set(RCLI_PINNED_KIT_SHA256_WINDOWS_ARM64 "673358bd8391bb28db0b947c8155ef193ffbe107cf518d088852ad6ecd39a9e1")


### PR DESCRIPTION
v0.20.33 fills NeuRT's `tts_ops` slot, so the ANE engine serves **eight** primitives rather
than seven.

Verified against the **published** release and its private overlay, not a local build:

```
neurt  prio=100  diffusion,embed,embed_image,generate_text,rerank,synthesize,transcribe,vlm

scripts/fetch-kit.sh macos-arm64   kit verified and extracted
cmake configure                    IDL pin check passed
cmake --build                      rc=0
```

## The IDL pin moves to 1.1.1

This retires the `0.20.32` note that deliberately held it at 1.1.0. That note was correct
for its release: 0.20.32 published via `publish_from_run_id`, reusing artifacts built
before the monorepo bumped `idl/VERSION` for a **comment-only** `.proto` edit — so its kit
genuinely carried the older lock, and pinning 1.1.1 would have failed `fetch-kit.sh`
against the very kit it validates. 0.20.33's kits were built after that bump, so these
values are read out of the shipped `SCHEMA_LOCK` rather than carried forward.

## One trap worth recording

The OSS kit alone **cannot** demonstrate any of this. `backends --json` lists no `neurt` at
all until the private overlay is applied, because NeuRT ships as a separate private pack:

```
skip: no private neurt overlay for macos-arm64 (OSS kit only)
```

A routability check run against the public bottle would report a clean — and meaningless —
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6p1R4pwTg5pvVjiEjq9ZA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled SDK kit to version 0.20.33.
  * Updated associated IDL metadata and platform-specific integrity checksums.
  * Retained the existing Protocol Buffers compiler version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->