### PR TITLE
fix(info): report windows as the platform instead of unknown

### DIFF
--- a/src/commands/cmd_info.cpp
+++ b/src/commands/cmd_info.cpp
@@ -43,6 +43,8 @@ void register_info(CLI::App& app, GlobalOptions& options) {
         const char* platform = "macos";
 #elif defined(__linux__)
         const char* platform = "linux";
+#elif defined(_WIN32)
+        const char* platform = "windows";
 #else
         const char* platform = "unknown";
 #endif


### PR DESCRIPTION
`rcli info` prints `platform unknown` on Windows — on the one command whose job is describing the machine.

```
platform   unknown
```

`src/commands/cmd_info.cpp` builds that string from a chain with branches for `__APPLE__` and `__linux__` and no `_WIN32`, so Windows falls through to the `else`:

```cpp
#if defined(__APPLE__)
        const char* platform = "macos";
#elif defined(__linux__)
        const char* platform = "linux";
#else
        const char* platform = "unknown";
#endif
```

This adds the missing branch. The value is not invented: `src/device_info.cpp` already reports `"windows"` from a proper `_WIN32` branch, so this makes `cmd_info.cpp` agree with a convention the tree already has rather than introducing a new one.

Two lines, no behaviour change on macOS or Linux.

**Tested:** Windows 11 Pro x64. Full `ctest` was not run: building `rcli` needs the pinned RunAnywhere C++ desktop kit, which is not on this machine and there is no MSVC here (MinGW-w64 g++ 15.2.0 only). What I did verify is the preprocessor chain itself, compiled verbatim on Windows with that g++:

```
before:   platform   unknown
after:    platform   windows
```

So this is UNVERIFIED against a real `rcli info` run — the change is two lines in a `#if` chain and I could not build the binary. Happy to have CI's `windows-2022` runner be the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GKWuztPetmifnvy92teYB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `info` command now correctly identifies Windows platforms instead of reporting them as unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->