### PR TITLE
fix(paths): stop emitting mixed separators in Windows paths

### DIFF
--- a/src/config/cli_paths.cpp
+++ b/src/config/cli_paths.cpp
@@ -45,6 +45,18 @@ std::string getenv_utf8(const char* name) {
 }  // namespace
 
 std::string normalize_dir(std::string dir) {
+#if defined(_WIN32)
+    // Windows environment values (LOCALAPPDATA, USERPROFILE) come back
+    // backslash-separated, while every path built from them here appends
+    // '/'-joined segments -- leaving `rcli info` printing a mixed
+    // C:\Users\...\AppData\Local/RunAnywhere. Fold to '/' so a single
+    // style survives into the output; Win32 accepts either separator.
+    for (char& c : dir) {
+        if (c == '\\') {
+            c = '/';
+        }
+    }
+#endif
     while (dir.size() > 1 && (dir.back() == '/' || dir.back() == '\\')) {
         dir.pop_back();
     }

--- a/tests/test_rcli_unit.cpp
+++ b/tests/test_rcli_unit.cpp
@@ -224,11 +224,29 @@ TestResult test_state_dir() {
   TestResult result;
   result.test_name = "state_dir";
 
-  EnvVar xdg("XDG_STATE_HOME", "/xdg-state");
-  if (rcli::paths::state_dir() != "/xdg-state/runanywhere") {
-    result.details = "XDG_STATE_HOME not honored";
-    return result;
+  {
+    EnvVar xdg("XDG_STATE_HOME", "/xdg-state");
+    if (rcli::paths::state_dir() != "/xdg-state/runanywhere") {
+      result.details = "XDG_STATE_HOME not honored";
+      return result;
+    }
   }
+#if defined(_WIN32)
+  {
+    // A real LOCALAPPDATA is backslash-separated while the suffix appended to
+    // it is not, so the join must not leave mixed separators behind. Note the
+    // backslashes here: the resolve_home case above passes a '/'-style value,
+    // which is why this never surfaced.
+    EnvVar xdg("XDG_STATE_HOME", nullptr);
+    EnvVar home("HOME", nullptr);
+    EnvVar local("LOCALAPPDATA", "C:\\rcli-local");
+    const std::string state = rcli::paths::state_dir();
+    if (state != "C:/rcli-local/RunAnywhere/state") {
+      result.details = "expected C:/rcli-local/RunAnywhere/state, got " + state;
+      return result;
+    }
+  }
+#endif
   result.passed = true;
   return result;
 }


### PR DESCRIPTION
`rcli info` prints a path with both separator styles in it on Windows:

```
C:\Users\...\AppData\Local/RunAnywhere
```

`state_dir()` and `resolve_home()` in `src/config/cli_paths.cpp` append `'/'`-joined segments to values read from `LOCALAPPDATA` / `USERPROFILE`, which Windows hands back backslash-separated. Nothing reconciles the two.

The fix folds backslashes to `/` inside `normalize_dir()`, which already runs over every one of those values — so both call sites are fixed in one place rather than patching each join. Win32 accepts either separator, and `/` is the style the existing `resolve_home` expectation is already written in (`tests/test_rcli_unit.cpp`, the `_WIN32` case expects `C:/rcli-local/RunAnywhere`).

### Why CI did not catch this

The Windows branch of `state_dir()` has no coverage at all. `test_state_dir()` asserts the `XDG_STATE_HOME` case and returns — it never reaches the `LOCALAPPDATA` branch, on any platform.

And the one Windows path case that does exist passes `LOCALAPPDATA` as `"C:/rcli-local"` — forward slashes — which is exactly the input that cannot reproduce the bug.

So this PR adds a `state_dir()` case that passes a realistically backslashed `LOCALAPPDATA`. It fails before the change and passes after, on the existing `windows-2022` runner. The pre-existing assertion is wrapped in a scope block so its `EnvVar` restores before the new case runs; without that `XDG_STATE_HOME` stays set and wins.

**Tested:** Windows 11 Pro x64, MinGW-w64 g++ 15.2.0. `ctest` was not run in full — building the test binary needs the pinned SDK kit (protobuf + `rac/*` headers), which is not on this machine. Instead I compiled `src/config/cli_paths.cpp` directly against a stub for its one SDK include (`rac_desktop_default_base_dir`, used only by `resolve_home`, not by `state_dir`) and ran the two `test_state_dir()` cases from this branch verbatim:

on `main`:

```
ok  xdg case -> /xdg-state/runanywhere
FAIL windows LOCALAPPDATA: expected C:/rcli-local/RunAnywhere/state, got C:cli-local/RunAnywhere/state
FAILED (1)
```

on this branch:

```
ok  xdg case -> /xdg-state/runanywhere
ok  windows LOCALAPPDATA case -> C:/rcli-local/RunAnywhere/state
PASSED (0 failures)
```

Red before, green after, on the real `state_dir()` source. The mixed separator in the failing line is the bug as reported. UNVERIFIED: the `rcli info` output itself, and the test under MSVC — neither is buildable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GKWuztPetmifnvy92teYB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Windows directory paths now consistently use forward slashes, including paths derived from environment settings.
  - Improved state directory resolution when Windows environment paths contain backslashes.

- **Tests**
  - Added coverage for Windows path normalization and state directory resolution across supported environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->