### PR TITLE
Let a dev build carry its console endpoints, from the environment only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,26 @@ target_include_directories(wally_core PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/third_party/linenoise"
 )
 
+# Dev endpoint bake. The values come from the ENVIRONMENT of the configure
+# step, never from -D flags: nothing endpoint-shaped lands on the command
+# line, in CMakeCache.txt, or in this log (only ON/off is printed). The
+# generated header lives in the build tree, which is gitignored — no endpoint
+# ever enters committed source. Empty env (the normal case) generates empty
+# macros and the production resolution order is untouched.
+set(WALLY_BAKED_CONSOLE_API_URL "$ENV{WALLY_BAKED_CONSOLE_API_URL}")
+set(WALLY_BAKED_CONSOLE_WEB_ORIGIN "$ENV{WALLY_BAKED_CONSOLE_WEB_ORIGIN}")
+if(WALLY_BAKED_CONSOLE_API_URL)
+    message(STATUS "wally: dev endpoint bake ON (values withheld from log)")
+else()
+    message(STATUS "wally: dev endpoint bake off (production defaults)")
+endif()
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/account/baked_endpoints.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/generated/account/baked_endpoints.h"
+    @ONLY
+)
+target_include_directories(wally_core PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
 # The Anthropic translator and the JetBrains proxy need an HTTP client and a
 # JSON reader. Both used to arrive from the SDK's own source build; a kit
 # consumer never configures that build, so they are fetched here.

--- a/src/account/baked_endpoints.h.in
+++ b/src/account/baked_endpoints.h.in
@@ -1,0 +1,17 @@
+// Configure-time endpoint bake — TEMPLATE. The real header is generated into
+// the build tree (never committed) by CMake from WALLY_BAKED_CONSOLE_API_URL /
+// WALLY_BAKED_CONSOLE_WEB_ORIGIN in the *environment* of the configure step.
+// Values never appear on the cmake command line, in the cache, or in logs.
+//
+// Both macros are empty strings in a normal build, and every consumer treats
+// empty as "no bake" — so a release build is byte-for-byte the production
+// resolution order it always had. A URL baked here is NOT a secret (anyone can
+// run `strings` on the binary); the discipline is about the pipeline: no
+// endpoint in committed source, none echoed by the build.
+#ifndef WALLY_ACCOUNT_BAKED_ENDPOINTS_H
+#define WALLY_ACCOUNT_BAKED_ENDPOINTS_H
+
+#define WALLY_BAKED_CONSOLE_API_URL "@WALLY_BAKED_CONSOLE_API_URL@"
+#define WALLY_BAKED_CONSOLE_WEB_ORIGIN "@WALLY_BAKED_CONSOLE_WEB_ORIGIN@"
+
+#endif  // WALLY_ACCOUNT_BAKED_ENDPOINTS_H

--- a/src/account/credentials.cpp
+++ b/src/account/credentials.cpp
@@ -1,5 +1,7 @@
 #include "account/credentials.h"
 
+#include "account/baked_endpoints.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
@@ -559,7 +561,16 @@ bool WriteDocument(const std::string& path, const std::string& document, std::st
 
 std::string DefaultConsoleUrl() {
     const std::string configured = EnvWithLegacyFallback("WALLY_CONSOLE_URL", "RCLI_CONSOLE_URL");
-    return configured.empty() ? kProductionConsoleApi : configured;
+    if (!configured.empty()) {
+        return configured;
+    }
+    // A dev build carries its control plane compiled in (see
+    // baked_endpoints.h.in): the env override above still wins, production
+    // builds generate an empty macro and fall through unchanged.
+    if (WALLY_BAKED_CONSOLE_API_URL[0] != '\0') {
+        return WALLY_BAKED_CONSOLE_API_URL;
+    }
+    return kProductionConsoleApi;
 }
 
 std::vector<std::string> TrustedBrowserOrigins(const std::string& console_url) {
@@ -572,6 +583,17 @@ std::vector<std::string> TrustedBrowserOrigins(const std::string& console_url) {
     }
     if (console_url == kProductionConsoleApi) {
         return {std::begin(kProductionConsoleWeb), std::end(kProductionConsoleWeb)};
+    }
+    // A dev build that baked its control plane also baked which browser
+    // console may approve sign-ins for it (a local console on loopback,
+    // typically). Trust holds pairwise: the baked web origin is honored only
+    // while talking to the baked API, never for an arbitrary --base-url.
+    if (WALLY_BAKED_CONSOLE_WEB_ORIGIN[0] != '\0' &&
+        console_url == std::string(WALLY_BAKED_CONSOLE_API_URL)) {
+        std::string baked_web;
+        if (NormalizeConsoleUrl(WALLY_BAKED_CONSOLE_WEB_ORIGIN, &baked_web, nullptr)) {
+            return {baked_web, console_url};
+        }
     }
     // Anything else — a dev console, a loopback stub — is trusted only at its
     // own origin. That is the rule that held before, and it is the safe answer

--- a/src/commands/cmd_account.cpp
+++ b/src/commands/cmd_account.cpp
@@ -16,6 +16,7 @@
 #include <sys/wait.h>
 #endif
 
+#include "account/baked_endpoints.h"
 #include "account/console.h"
 #include "account/credentials.h"
 #include "commands/commands.h"
@@ -45,6 +46,12 @@ std::string ConsoleWebOrigin() {
         // rcli-era override, still honored so it doesn't go silently unread
         // after the wally rename.
         configured = std::getenv("RCLI_CONSOLE_WEB_URL");
+    }
+    if (configured == nullptr || *configured == '\0') {
+        // A dev build carries its approval console compiled in (see
+        // baked_endpoints.h.in) — empty in production builds, and the env
+        // overrides above always win.
+        configured = WALLY_BAKED_CONSOLE_WEB_ORIGIN;
     }
     std::string origin;
     if (configured == nullptr || *configured == '\0' ||


### PR DESCRIPTION
A dev build can now carry its control plane and its approval console compiled
in, so signing in against development does not need two environment variables
set correctly in every shell.

## How it works

`CMakeLists.txt` reads `WALLY_BAKED_CONSOLE_API_URL` and
`WALLY_BAKED_CONSOLE_WEB_ORIGIN` from the **environment** of the configure step
and generates a header into the build tree. `DefaultConsoleUrl()`,
`TrustedBrowserOrigins()` and `ConsoleWebOrigin()` fall back to those values.

## Why the environment and not `-D`

Nothing endpoint-shaped should land on a command line, in `CMakeCache.txt`, or
in a build log. The configure step prints only whether the bake is on:

```
-- wally: dev endpoint bake off (production defaults)
```

The generated header lives under `build/`, which is gitignored, so no endpoint
enters committed source. A baked URL is not a secret, anyone can run `strings`
on the binary. The discipline is about the pipeline.

## Why a release build is unaffected

Empty environment generates empty macros, and every consumer treats empty as
"no bake". A release build keeps exactly the resolution order it had:
environment override, then the production constant. Verified here with the bake
off: configure reports "off", the build is clean, `ctest` is 8/8.

An environment override still wins over a baked value, so a dev binary can
still be pointed somewhere else for one command.

## The trust rule

The baked approval origin is honoured **only** while talking to the baked API,
never for an arbitrary `--console-url`. Pairing them is what keeps this from
becoming an origin-confusion hole: a dev build will not approve a sign-in from
its baked console for some other console's API.

Based on `siddhesh/wally-renaming`, and on top of the console-URL base-path fix
already on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaUjT39Ua98Wknrx9FdxX1
