### PR TITLE
release: fix linux, windows, and dev-bottle packaging

### DIFF
--- a/scripts/build/package-wally-windows.ps1
+++ b/scripts/build/package-wally-windows.ps1
@@ -26,7 +26,12 @@ $Suffix = if ($Channel -eq "dev") { "-dev" } else { "" }
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$CliRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+# This script lives in scripts/build, so the repo root is two levels up, not
+# one. At one level $CliRoot was scripts/, and a relative -BuildDir "build"
+# resolved to scripts/build, where no wally.exe exists -- the packaging step
+# failed with "wally.exe was not found under ...\scripts\build". Matches the
+# bash packager's ROOT=$SCRIPT_DIR/../.. .
+$CliRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
 if (-not [IO.Path]::IsPathRooted($BuildDir)) {
     $BuildDir = Join-Path $CliRoot $BuildDir
 }

--- a/scripts/build/package-wally.sh
+++ b/scripts/build/package-wally.sh
@@ -85,8 +85,13 @@ if [[ -n "${KIT}" && -d "${KIT}/third_party" ]]; then
       copy_kit_runtime "${KIT}/third_party/libonnxruntime.dylib"
       ;;
     linux-*)
+      # Every shared object the kit ships, not just onnxruntime: the binary
+      # dynamically links sherpa too (libsherpa-onnx-c-api.so), and a bottle
+      # missing any one of them fails to load with `cannot open shared object
+      # file` the moment it runs -- which the `wally version` smoke below is
+      # here to catch. patchelf's $ORIGIN/../lib rpath resolves them from here.
       shopt -s nullglob
-      for so in "${KIT}/third_party"/libonnxruntime.so*; do
+      for so in "${KIT}/third_party"/*.so*; do
         copy_kit_runtime "${so}"
       done
       shopt -u nullglob

--- a/scripts/release/verify-release-assets.py
+++ b/scripts/release/verify-release-assets.py
@@ -12,9 +12,13 @@ import tarfile
 import zipfile
 
 
+# The dev bottle differs only in an added `-dev` before the extension; its
+# staged root is still wally-<platform> (package scripts keep them identical so
+# install extracts both the same), so `platform` must exclude the channel.
 ASSET = re.compile(
     r"^wally-(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-"
-    r"(?P<platform>macos-arm64|windows-x86_64)\.(?P<suffix>tar\.gz|zip)$"
+    r"(?P<platform>macos-arm64|linux-x86_64|windows-x86_64|windows-arm64)"
+    r"(?P<channel>-dev)?\.(?P<suffix>tar\.gz|zip)$"
 )
 MAX_MEMBERS = 100_000
 MAX_UNCOMPRESSED_BYTES = 4 * 1024 * 1024 * 1024

--- a/tests/test_release_assets.py
+++ b/tests/test_release_assets.py
@@ -44,6 +44,33 @@ class ReleaseAssetTests(unittest.TestCase):
                 self.add_tar_file(bundle, "wally-macos-arm64/bin/wally", b"binary", 0o755)
             VERIFY.verify(archive, self.sidecar(archive))
 
+    def test_valid_linux_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "wally-1.2.3-linux-x86_64.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                self.add_tar_file(bundle, "wally-linux-x86_64/README.md", b"readme", 0o644)
+                self.add_tar_file(bundle, "wally-linux-x86_64/bin/wally", b"binary", 0o755)
+            VERIFY.verify(archive, self.sidecar(archive))
+
+    def test_valid_windows_arm64_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "wally-1.2.3-windows-arm64.zip"
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("wally-windows-arm64/README.md", b"readme")
+                bundle.writestr("wally-windows-arm64/bin/wally.exe", b"binary")
+            VERIFY.verify(archive, self.sidecar(archive))
+
+    def test_valid_dev_bottle_shares_the_platform_root(self) -> None:
+        # The -dev bottle only adds -dev to the filename; its staged root stays
+        # wally-<platform>. This is the exact asset name the release verify
+        # rejected before the channel group was added.
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "wally-0.5.3-macos-arm64-dev.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                self.add_tar_file(bundle, "wally-macos-arm64/README.md", b"readme", 0o644)
+                self.add_tar_file(bundle, "wally-macos-arm64/bin/wally", b"binary", 0o755)
+            VERIFY.verify(archive, self.sidecar(archive))
+
     def test_valid_windows_archive_with_backslash_members(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             archive = pathlib.Path(temporary) / "wally-1.2.3-windows-x86_64.zip"


### PR DESCRIPTION
The v0.5.3 release run failed on every Linux and Windows bottle and on all the
dev bottles. Three separate packaging bugs, none in the compile:

- **Linux** — the packager staged only `libonnxruntime.so*`, so the binary
  couldn't load `libsherpa-onnx-c-api.so` at runtime and the `wally version`
  smoke exited 127. It now stages every `.so` the kit ships.
- **Windows** — `package-wally-windows.ps1` took the repo root as one level up
  from `scripts/build` (i.e. `scripts/`), so `-BuildDir build` resolved to
  `scripts/build` and `wally.exe` was never found. Fixed to two levels up, to
  match the bash packager.
- **Asset verify** — `verify-release-assets.py` only accepted `macos-arm64` and
  `windows-x86_64`, no `-dev`, no `linux-x86_64`, no `windows-arm64`. It now
  accepts all four platforms and the `-dev` channel.

Tests: added linux, windows-arm64, and `-dev` cases to `test_release_assets.py`
(the `-dev` one is the exact name the run rejected). macOS prod already passed;
the macOS dev bottle packages and verifies locally with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows packaging so builds are located correctly when using relative paths.
  * Linux packages now include all required shared libraries, improving runtime compatibility.
  * Release asset verification now recognizes Linux x86_64, Windows ARM64, and development-channel packages.

* **Tests**
  * Added coverage for Linux, Windows ARM64, and development package archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->