### PR TITLE
release: ship linux bottle without .so symlinks

### DIFF
--- a/scripts/build/package-wally.sh
+++ b/scripts/build/package-wally.sh
@@ -76,7 +76,12 @@ fi
 copy_kit_runtime() {
   local src="$1"
   [[ -n "${src}" && -e "${src}" ]] || return 0
-  cp -R "${src}" "${STAGE}/lib/"
+  # -L dereferences: the kit ships onnxruntime as a
+  # libonnxruntime.so -> .so.1 -> .so.1.28.0 symlink chain, and the release
+  # verifier rejects symlinks in a bottle (they can escape the archive root).
+  # Copying the targets as real files keeps the soname the binary needs present
+  # without a link. A dangling link is skipped by the -e guard above.
+  cp -RL "${src}" "${STAGE}/lib/"
 }
 
 if [[ -n "${KIT}" && -d "${KIT}/third_party" ]]; then


### PR DESCRIPTION
Follow-up to #66. The v0.5.3 re-run got Windows and macOS green and the Linux
`.so` staging worked (the `wally version` smoke passed), but Verify archive then
rejected the linux bottle: the kit ships onnxruntime as a
`libonnxruntime.so -> .so.1 -> .so.1.28.0` symlink chain, `cp -R` preserved the
links, and the verifier rejects symlinks in a bottle (they can escape the root).

`cp -RL` dereferences them, so the bottle ships real files and the soname the
binary needs (`libonnxruntime.so.1`) is present without a link. macOS is
unaffected (single real dylib).
