### PR TITLE
skill: add the install step so it's self-sufficient

### DIFF
--- a/skills/runanywhere/SKILL.md
+++ b/skills/runanywhere/SKILL.md
@@ -10,6 +10,20 @@ served from **RunAnywhere Cloud**. The same commands cover both — if a model i
 on the machine it is served locally, otherwise the request goes to the console
 the user is signed in to and is metered against their balance.
 
+## Install `wally` if it is missing
+
+If `wally` is not on PATH, install it first — one line, no configuration and no
+key to copy:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/RunanywhereAI/wally/main/install.sh | sh
+```
+
+macOS (Apple Silicon) and Linux x86-64. On Windows:
+`irm https://raw.githubusercontent.com/RunanywhereAI/wally/main/install.ps1 | iex`.
+The installer only puts `wally` on PATH and writes this skill; it signs nothing
+in on its own.
+
 ## First check what is already true
 
 ```bash


### PR DESCRIPTION
The installed skill assumed `wally` was already on PATH and jumped straight to
`wally whoami`, so an assistant reading it had no way to install `wally` if it
was missing (a fresh machine, or the binary removed). The description said
"install wally" but the body never showed how.

Adds the one-line install step up front, matching the marketing skill served at
runanywhere.ai/SKILL.md. Ships in the next release (install.sh fetches the skill
pinned to the release tag).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for installing `wally` when it is unavailable on the system PATH.
  - Documented installation options for macOS (Apple Silicon), Linux x86-64, and Windows via PowerShell.
  - Clarified that the installer updates PATH and writes the skill without signing users in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->