### PR TITLE
harness: add `wally codex` (hosted, Responses API)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(WALLY_SOURCES
     src/desktop/claude_profile.cpp
     src/harness/harness.cpp
     src/harness/opencode.cpp
+    src/harness/codex.cpp
     src/harness/local_models.cpp
     src/ide/jetbrains_profile.cpp
     src/ide/openai_proxy.cpp

--- a/scripts/dev/codex-e2e.sh
+++ b/scripts/dev/codex-e2e.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Manual end-to-end check of the `wally codex` launch pattern, against a real
+# model, off any of our infrastructure.
+#
+# Codex is Responses-API-only, and most OpenAI-compatible backends (Gemini here)
+# speak chat/completions, so a thin LiteLLM bridge does the responses->chat
+# translation — the same translation our gateway does. The point it proves: the
+# throwaway CODEX_HOME + key-via-env + Responses wire that `wally codex` builds
+# drives a real model to a real answer, in one command, without touching the
+# user's own ~/.codex.
+#
+#   GEMINI_API_KEY=... scripts/dev/codex-e2e.sh
+#
+# Override CODEX / LITELLM if they are not on PATH. Not a hermetic test and not
+# wired into CI: it needs the codex and litellm binaries and a live key.
+set -euo pipefail
+KEY="${GEMINI_API_KEY:?set GEMINI_API_KEY (a Gemini/generativelanguage key)}"
+CODEX="${CODEX:-$(command -v codex || true)}"
+LITELLM="${LITELLM:-$(command -v litellm || true)}"
+MODEL="${MODEL:-gemini-flash-lite-latest}"
+PORT="${PORT:-4123}"
+[ -x "$CODEX" ]   || { echo "codex not found — set CODEX=/path/to/codex" >&2; exit 1; }
+[ -x "$LITELLM" ] || { echo "litellm not found — set LITELLM=/path/to/litellm" >&2; exit 1; }
+
+TMP="$(mktemp -d)"; LLPID=""
+cleanup() { [ -n "$LLPID" ] && kill "$LLPID" 2>/dev/null || true; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+cat > "$TMP/litellm.yaml" <<YAML
+model_list:
+  - model_name: bridge-model
+    litellm_params:
+      model: gemini/${MODEL}
+      api_key: os.environ/GEMINI_API_KEY
+general_settings:
+  master_key: sk-local-validate
+YAML
+
+echo "== starting LiteLLM bridge (:$PORT) =="
+GEMINI_API_KEY="$KEY" "$LITELLM" --config "$TMP/litellm.yaml" --port "$PORT" > "$TMP/litellm.log" 2>&1 &
+LLPID=$!
+ready=0
+for _ in $(seq 1 60); do
+  curl -sf "http://localhost:$PORT/health/liveliness" >/dev/null 2>&1 && { ready=1; break; }
+  sleep 1
+done
+[ "$ready" = 1 ] || { echo "LiteLLM did not come up:"; tail -20 "$TMP/litellm.log"; exit 1; }
+
+# Same ephemeral CODEX_HOME + Responses wire `wally codex` writes.
+CODEX_HOME_DIR="$TMP/codex-home"; WORK="$TMP/work"; mkdir -p "$CODEX_HOME_DIR" "$WORK"
+chmod 700 "$CODEX_HOME_DIR"
+cat > "$CODEX_HOME_DIR/config.toml" <<TOML
+model = "bridge-model"
+model_provider = "bridge"
+
+[model_providers.bridge]
+name = "Local bridge"
+base_url = "http://localhost:$PORT/v1"
+env_key = "BRIDGE_KEY"
+wire_api = "responses"
+TOML
+
+echo "== running codex (one command) =="
+out="$(CODEX_HOME="$CODEX_HOME_DIR" BRIDGE_KEY="sk-local-validate" \
+  "$CODEX" exec --skip-git-repo-check --sandbox read-only \
+  -c 'approval_policy="never"' --cd "$WORK" "reply with exactly the token: CODEX_OK" 2>&1)" || true
+echo "$out" | tail -25
+
+echo "== verdict =="
+# The prompt echoes the token once; a real model answer makes it appear again.
+n="$(printf '%s' "$out" | grep -c 'CODEX_OK' || true)"
+if [ "${n:-0}" -ge 2 ]; then
+  echo "PASS: codex ran end to end (Responses API) and the model answered"
+else
+  echo "FAIL: no model answer"; echo "--- litellm log tail ---"; tail -20 "$TMP/litellm.log"; exit 1
+fi

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -164,8 +164,8 @@ int run(int argc, char** argv) {
     // cloud path exists.
     app.footer(
         "A model your account has on the hosted console (not this machine) runs through "
-        "`wally claude-code -m <id>` or `wally opencode --cloud -m <id>`, not `run`/`llm "
-        "generate`.");
+        "`wally claude-code -m <id>`, `wally opencode --cloud -m <id>` or "
+        "`wally codex -m <id>`, not `run`/`llm generate`.");
 
     int exit_code = 0;
     try {

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -109,9 +109,9 @@ void configure_app(CLI::App& app, GlobalOptions& options) {
         {"about", "Serve & measure"},    {"version", "Serve & measure"},
         {"auth", "Account"},      {"login", "Account"},      {"logout", "Account"},
         {"whoami", "Account"},    {"usage", "Account"},
-        {"opencode", "Editors & agents"},    {"claude-code", "Editors & agents"},
-        {"claude-desktop", "Editors & agents"}, {"clion", "Editors & agents"},
-        {"rustrover", "Editors & agents"},
+        {"opencode", "Editors & agents"},    {"codex", "Editors & agents"},
+        {"claude-code", "Editors & agents"}, {"claude-desktop", "Editors & agents"},
+        {"clion", "Editors & agents"},       {"rustrover", "Editors & agents"},
     };
     // configure_app() runs ahead of run()'s own try/catch (and tests call it
     // directly with none at all), so a typo here must never propagate as an

--- a/src/commands/cmd_harness.cpp
+++ b/src/commands/cmd_harness.cpp
@@ -5,6 +5,7 @@
 #include "catalog/catalog.h"
 #include "commands/commands.h"
 #include "io/output.h"
+#include "harness/codex.h"
 #include "harness/harness.h"
 #include "harness/opencode.h"
 
@@ -47,6 +48,24 @@ void register_harness(CLI::App& app, GlobalOptions& options) {
             return;
         }
         fail(harness::Launch("opencode", *model, *rest));
+    });
+
+    // Codex speaks the Responses API, which the hosted gateway serves and a
+    // local `wally serve` does not, so `wally codex` is hosted-only for now.
+    // Same prefix-command passthrough as opencode.
+    auto codex_model = std::make_shared<std::string>();
+    auto codex_rest = std::make_shared<std::vector<std::string>>();
+    auto* codex =
+        app.add_subcommand("codex", "open a coding session in Codex against a hosted model");
+    codex->add_option("-m,--model", *codex_model, "a console model id (e.g. glm-5.3-flash)");
+    codex->add_option("args", *codex_rest, "passed through to codex")->allow_extra_args();
+    codex->prefix_command();
+    codex->callback([codex_model, codex_rest] {
+        if (codex_model->empty()) {
+            out::error_line("wally codex needs a hosted model: wally codex -m <console-model-id>");
+            fail(2);
+        }
+        fail(harness::LaunchCodexCloud(*codex_model, *codex_rest));
     });
 }
 

--- a/src/harness/codex.cpp
+++ b/src/harness/codex.cpp
@@ -1,0 +1,251 @@
+#include "harness/codex.h"
+
+#include "harness/harness.h"
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+
+#include <sys/wait.h>
+#endif
+
+#include "account/credentials.h"
+#include "io/output.h"
+
+namespace wally::harness {
+namespace {
+
+namespace fs = std::filesystem;
+
+bool SetEnvironment(const char* name, const std::string& value) {
+#if defined(_WIN32)
+    return _putenv_s(name, value.c_str()) == 0;
+#else
+    return setenv(name, value.c_str(), 1) == 0;
+#endif
+}
+
+bool UnsetEnvironment(const char* name) {
+#if defined(_WIN32)
+    return _putenv_s(name, "") == 0;
+#else
+    return unsetenv(name) == 0;
+#endif
+}
+
+/// Restores one environment variable to whatever it was, or removes it if it
+/// had no prior value. Copied rather than shared with opencode's because the
+/// two harnesses set different variables and must not couple.
+class ScopedEnv {
+   public:
+    ScopedEnv() = default;
+    ScopedEnv(const ScopedEnv&) = delete;
+    ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+    ~ScopedEnv() {
+        if (name_ == nullptr) {
+            return;
+        }
+        if (had_previous_) {
+            static_cast<void>(SetEnvironment(name_, previous_));
+        } else {
+            static_cast<void>(UnsetEnvironment(name_));
+        }
+    }
+
+    bool Set(const char* name, const std::string& value) {
+        name_ = name;
+        if (const char* previous = std::getenv(name)) {
+            had_previous_ = true;
+            previous_ = previous;
+        }
+        return SetEnvironment(name, value);
+    }
+
+   private:
+    const char* name_ = nullptr;
+    std::string previous_;
+    bool had_previous_ = false;
+};
+
+/// A throwaway CODEX_HOME holding just config.toml, wiped on destruction. Codex
+/// reads its provider from $CODEX_HOME/config.toml, so this is how a launch
+/// points Codex at the RunAnywhere endpoint without touching the user's own
+/// ~/.codex.
+class ScopedCodexHome {
+   public:
+    ScopedCodexHome() = default;
+    ScopedCodexHome(const ScopedCodexHome&) = delete;
+    ScopedCodexHome& operator=(const ScopedCodexHome&) = delete;
+
+    ~ScopedCodexHome() {
+        if (dir_.empty()) {
+            return;
+        }
+        std::error_code ec;
+        fs::remove_all(dir_, ec);
+    }
+
+    /// Create the directory and write config.toml into it. Returns false and
+    /// leaves nothing behind on any failure.
+    bool Write(const std::string& config) {
+        std::error_code ec;
+        std::random_device rd;
+        const fs::path base = fs::temp_directory_path(ec);
+        if (ec) {
+            return false;
+        }
+        const fs::path candidate =
+            base / ("wally-codex-" + std::to_string(rd()) + std::to_string(rd()));
+        if (!fs::create_directory(candidate, ec) || ec) {
+            return false;
+        }
+        dir_ = candidate;
+        std::ofstream out(dir_ / "config.toml", std::ios::binary | std::ios::trunc);
+        out << config;
+        out.flush();
+        if (!out) {
+            fs::remove_all(dir_, ec);
+            dir_.clear();
+            return false;
+        }
+        return true;
+    }
+
+    const fs::path& dir() const { return dir_; }
+
+   private:
+    fs::path dir_;
+};
+
+/// Not an error line. Codex simply is not here yet; the useful thing is how to
+/// get it. Codex is distributed on npm as @openai/codex.
+void MissingCodex() {
+    out::status_line("codex is not installed on this machine");
+    out::status_line("install it with `npm i -g @openai/codex`, then run this again");
+}
+
+int Spawn(const std::string& executable, const std::vector<std::string>& arguments) {
+    std::vector<std::string> owned;
+    owned.reserve(arguments.size() + 1);
+    owned.push_back(executable);
+    owned.insert(owned.end(), arguments.begin(), arguments.end());
+
+    std::vector<char*> argv;
+    argv.reserve(owned.size() + 1);
+    for (std::string& value : owned) {
+        argv.push_back(value.data());
+    }
+    argv.push_back(nullptr);
+
+#if defined(_WIN32)
+    const intptr_t status = _spawnvp(_P_WAIT, executable.c_str(), argv.data());
+    if (status < 0) {
+        MissingCodex();
+        return 127;
+    }
+    return static_cast<int>(status);
+#else
+    const pid_t child = fork();
+    if (child < 0) {
+        out::error_line("could not start Codex");
+        return 1;
+    }
+    if (child == 0) {
+        execvp(executable.c_str(), argv.data());
+        _exit(127);
+    }
+
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0) {
+        if (errno == EINTR) {
+            continue;
+        }
+        out::error_line("lost track of Codex");
+        return 1;
+    }
+    if (!WIFEXITED(status)) {
+        return 1;
+    }
+    const int exit_code = WEXITSTATUS(status);
+    if (exit_code == 127) {
+        MissingCodex();
+    }
+    return exit_code;
+#endif
+}
+
+}  // namespace
+
+std::string BuildCodexConfig(const std::string& model, const std::string& base_url) {
+    // TOML basic strings. `model` is ModelIdIsSafe-checked and `base_url` is the
+    // console URL wally itself holds, so neither carries a quote or newline to
+    // escape here.
+    std::string config;
+    config += "model = \"" + model + "\"\n";
+    config += "model_provider = \"runanywhere\"\n\n";
+    config += "[model_providers.runanywhere]\n";
+    config += "name = \"RunAnywhere\"\n";
+    config += "base_url = \"" + base_url + "\"\n";
+    config += "env_key = \"" + std::string(kCodexKeyEnvVar) + "\"\n";
+    config += "wire_api = \"responses\"\n";
+    return config;
+}
+
+int LaunchCodexCloud(const std::string& model, const std::vector<std::string>& arguments,
+                     const account::ConsoleClient& console, const SpawnFunction& spawn) {
+    // The same gates the opencode cloud path gets: a real model id and a
+    // verified session, never a fabricated token launching a real agent.
+    if (!ModelIdIsSafe(model)) {
+        out::error_line("'" + model + "' is not a valid model id");
+        return 2;
+    }
+
+    account::Credentials credentials;
+    std::string error;
+    if (!account::Load(&credentials, &error)) {
+        out::error_line(error);
+        return 1;
+    }
+    if (!credentials.signed_in()) {
+        out::error_line("not signed in - run `wally login`");
+        return 1;
+    }
+    if (!VerifyCloudSession(console, &credentials, nullptr, &error)) {
+        out::error_line("the signed-in cloud session did not check out: " + error);
+        return 1;
+    }
+
+    const std::string base_url = credentials.console_url + "/v1";
+    ScopedCodexHome home;
+    if (!home.Write(BuildCodexConfig(model, base_url))) {
+        out::error_line("could not write the temporary Codex configuration");
+        return 1;
+    }
+
+    ScopedEnv codex_home;
+    ScopedEnv codex_key;
+    if (!codex_home.Set("CODEX_HOME", home.dir().string()) ||
+        !codex_key.Set(kCodexKeyEnvVar, credentials.access_token)) {
+        out::error_line("could not set the temporary Codex environment");
+        return 1;
+    }
+
+    out::status_line("launching Codex (Responses API) with the RunAnywhere cloud session");
+    return spawn("codex", arguments);
+}
+
+int LaunchCodexCloud(const std::string& model, const std::vector<std::string>& arguments) {
+    const account::ConsoleClient console;
+    return LaunchCodexCloud(model, arguments, console, Spawn);
+}
+
+}  // namespace wally::harness

--- a/src/harness/codex.cpp
+++ b/src/harness/codex.cpp
@@ -108,6 +108,11 @@ class ScopedCodexHome {
         if (!fs::create_directory(candidate, ec) || ec) {
             return false;
         }
+        // Owner-only: CODEX_HOME can hold config.toml and, if Codex ever writes
+        // one, an auth file, so it must not be world- or group-readable in the
+        // shared temp directory. Best-effort; a filesystem without POSIX perms
+        // (or Windows) simply keeps its own default ACLs.
+        fs::permissions(candidate, fs::perms::owner_all, fs::perm_options::replace, ec);
         dir_ = candidate;
         std::ofstream out(dir_ / "config.toml", std::ios::binary | std::ios::trunc);
         out << config;

--- a/src/harness/codex.cpp
+++ b/src/harness/codex.cpp
@@ -138,7 +138,63 @@ void MissingCodex() {
     out::status_line("install it with `npm i -g @openai/codex`, then run this again");
 }
 
+#if defined(_WIN32)
+// Quote one argument so the child re-parses it as a single token. The _spawn*
+// family joins argv into a command line WITHOUT quoting, so an argument that
+// contains a space would otherwise arrive split in two. Rules per the
+// documented MSVCRT parser: double the run of backslashes that precedes a quote
+// (or the closing quote), and backslash-escape embedded quotes. The POSIX path
+// needs none of this -- execvp hands argv to the child verbatim.
+std::string QuoteWindowsArg(const std::string& arg) {
+    if (!arg.empty() && arg.find_first_of(" \t\n\v\"") == std::string::npos) {
+        return arg;
+    }
+    std::string quoted = "\"";
+    for (std::size_t i = 0;; ++i) {
+        std::size_t backslashes = 0;
+        while (i < arg.size() && arg[i] == '\\') {
+            ++i;
+            ++backslashes;
+        }
+        if (i == arg.size()) {
+            quoted.append(backslashes * 2, '\\');
+            break;
+        }
+        if (arg[i] == '"') {
+            quoted.append(backslashes * 2 + 1, '\\');
+            quoted.push_back('"');
+        } else {
+            quoted.append(backslashes, '\\');
+            quoted.push_back(arg[i]);
+        }
+    }
+    quoted.push_back('"');
+    return quoted;
+}
+#endif
+
 int Spawn(const std::string& executable, const std::vector<std::string>& arguments) {
+#if defined(_WIN32)
+    std::vector<std::string> owned;
+    owned.reserve(arguments.size() + 1);
+    owned.push_back(QuoteWindowsArg(executable));
+    for (const std::string& argument : arguments) {
+        owned.push_back(QuoteWindowsArg(argument));
+    }
+    std::vector<char*> argv;
+    argv.reserve(owned.size() + 1);
+    for (std::string& value : owned) {
+        argv.push_back(value.data());
+    }
+    argv.push_back(nullptr);
+
+    const intptr_t status = _spawnvp(_P_WAIT, executable.c_str(), argv.data());
+    if (status < 0) {
+        MissingCodex();
+        return 127;
+    }
+    return static_cast<int>(status);
+#else
     std::vector<std::string> owned;
     owned.reserve(arguments.size() + 1);
     owned.push_back(executable);
@@ -151,14 +207,6 @@ int Spawn(const std::string& executable, const std::vector<std::string>& argumen
     }
     argv.push_back(nullptr);
 
-#if defined(_WIN32)
-    const intptr_t status = _spawnvp(_P_WAIT, executable.c_str(), argv.data());
-    if (status < 0) {
-        MissingCodex();
-        return 127;
-    }
-    return static_cast<int>(status);
-#else
     const pid_t child = fork();
     if (child < 0) {
         out::error_line("could not start Codex");

--- a/src/harness/codex.h
+++ b/src/harness/codex.h
@@ -1,0 +1,37 @@
+#ifndef WALLY_HARNESS_CODEX_H
+#define WALLY_HARNESS_CODEX_H
+
+#include <string>
+#include <vector>
+
+#include "account/console.h"
+#include "harness/opencode.h"  // SpawnFunction
+
+namespace wally::harness {
+
+/// The environment variable Codex reads the key from. Named in config.toml's
+/// `env_key`, exported for the child only, so the credential is never written
+/// to the config file or passed on argv.
+inline constexpr const char* kCodexKeyEnvVar = "WALLY_CODEX_API_KEY";
+
+/// Codex's `config.toml` for one hosted model. The key is deliberately absent —
+/// the provider block names `kCodexKeyEnvVar` and Codex reads it at runtime.
+/// Codex speaks the Responses API (`wire_api = "responses"`). Exposed so the
+/// contract can be tested without launching a child or touching the filesystem.
+std::string BuildCodexConfig(const std::string& model, const std::string& base_url);
+
+/// Launch Codex against the signed-in RunAnywhere cloud session.
+///
+/// Codex reads its provider from `$CODEX_HOME/config.toml`, so this writes a
+/// throwaway CODEX_HOME for the child and removes it afterwards, and passes the
+/// key through `kCodexKeyEnvVar` rather than into the file. The user's real
+/// ~/.codex is never read or written.
+int LaunchCodexCloud(const std::string& model, const std::vector<std::string>& arguments);
+
+/// Test seam for the console refresh transport and child process.
+int LaunchCodexCloud(const std::string& model, const std::vector<std::string>& arguments,
+                     const account::ConsoleClient& console, const SpawnFunction& spawn);
+
+}  // namespace wally::harness
+
+#endif  // WALLY_HARNESS_CODEX_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,12 @@ target_link_libraries(test_wally_opencode PRIVATE wally_core nlohmann_json::nloh
 wally_stage_windows_runtime_dlls(test_wally_opencode)
 add_test(NAME wally_opencode_tests COMMAND test_wally_opencode --run-all)
 
+add_executable(test_wally_codex test_wally_codex.cpp)
+target_include_directories(test_wally_codex PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(test_wally_codex PRIVATE wally_core nlohmann_json::nlohmann_json)
+wally_stage_windows_runtime_dlls(test_wally_codex)
+add_test(NAME wally_codex_tests COMMAND test_wally_codex --run-all)
+
 add_executable(test_wally_harness test_wally_harness.cpp)
 target_include_directories(test_wally_harness PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(test_wally_harness PRIVATE wally_core nlohmann_json::nlohmann_json)

--- a/tests/test_wally_codex.cpp
+++ b/tests/test_wally_codex.cpp
@@ -1,0 +1,223 @@
+#include "test_common.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "account/console.h"
+#include "account/credentials.h"
+#include "harness/codex.h"
+
+namespace {
+
+namespace fs = std::filesystem;
+using Json = nlohmann::json;
+
+class Environment {
+   public:
+    Environment(const char* name, const char* value) : name_(name) {
+        if (const char* previous = std::getenv(name)) {
+            had_previous_ = true;
+            previous_ = previous;
+        }
+        Set(value);
+    }
+    ~Environment() { Set(had_previous_ ? previous_.c_str() : nullptr); }
+
+   private:
+    void Set(const char* value) {
+#if defined(_WIN32)
+        _putenv_s(name_.c_str(), value != nullptr ? value : "");
+#else
+        value != nullptr ? setenv(name_.c_str(), value, 1) : unsetenv(name_.c_str());
+#endif
+    }
+    std::string name_;
+    std::string previous_;
+    bool had_previous_ = false;
+};
+
+class TemporaryDirectory {
+   public:
+    TemporaryDirectory() {
+        const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path() / ("wally-codex-test-" + std::to_string(nonce));
+        fs::create_directories(path_);
+    }
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+    const fs::path& path() const { return path_; }
+
+   private:
+    fs::path path_;
+};
+
+long long Now() {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+bool Seed(const fs::path& profile, long long expires_at, std::string* error) {
+    Environment scoped_profile("WALLY_PROFILE_DIR", profile.string().c_str());
+    wally::account::Credentials credentials;
+    credentials.console_url = "https://console.runanywhere.ai";
+    credentials.email = "developer@example.test";
+    credentials.access_token = "old-access-token";
+    credentials.refresh_token = "refresh-token";
+    credentials.expires_at = expires_at;
+    return wally::account::Save(credentials, error);
+}
+
+std::string ReadFile(const fs::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+wally::account::ConsoleClient WhoAmIConsole() {
+    return wally::account::ConsoleClient(
+        [](const wally::account::HttpRequest& request, wally::account::HttpResponse* response,
+           std::string*) {
+            if (!request.url.ends_with("/v1/me")) {
+                return false;
+            }
+            response->status = 200;
+            response->body = Json{{"email", "developer@example.test"}}.dump();
+            return true;
+        });
+}
+
+// The config names the env var and never carries the key, and the provider
+// talks the Responses API.
+TestResult test_build_config_names_key_env_and_responses() {
+    TestResult result;
+    result.test_name = "build_config_names_key_env_and_responses";
+    const std::string config =
+        wally::harness::BuildCodexConfig("glm-5.3-flash", "https://console.runanywhere.ai/v1");
+    const bool ok = config.find("model = \"glm-5.3-flash\"") != std::string::npos &&
+                    config.find("base_url = \"https://console.runanywhere.ai/v1\"") !=
+                        std::string::npos &&
+                    config.find("env_key = \"WALLY_CODEX_API_KEY\"") != std::string::npos &&
+                    config.find("wire_api = \"responses\"") != std::string::npos &&
+                    config.find("old-access-token") == std::string::npos;
+    if (!ok) {
+        result.details = "config.toml missing provider fields or leaked the key";
+        result.actual = config;
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+TestResult test_ephemeral_home_key_env_and_passthrough() {
+    TestResult result;
+    result.test_name = "ephemeral_home_key_env_and_passthrough";
+    TemporaryDirectory temporary;
+    Environment profile("WALLY_PROFILE_DIR", temporary.path().string().c_str());
+    Environment existing_home("CODEX_HOME", nullptr);
+    Environment existing_key("WALLY_CODEX_API_KEY", nullptr);
+    std::string error;
+    if (!Seed(temporary.path(), Now() + 3600, &error)) {
+        result.details = error;
+        return result;
+    }
+
+    bool spawned = false;
+    fs::path captured_home;
+    const std::vector<std::string> arguments = {"exec", "write a haiku"};
+    const wally::account::ConsoleClient console = WhoAmIConsole();
+    const int status = wally::harness::LaunchCodexCloud(
+        "glm-5.3", arguments, console,
+        [&](const std::string& executable, const std::vector<std::string>& received) {
+            spawned = true;
+            if (executable != "codex" || received != arguments) {
+                return 91;
+            }
+            const char* home = std::getenv("CODEX_HOME");
+            const char* key = std::getenv("WALLY_CODEX_API_KEY");
+            if (home == nullptr || key == nullptr || std::string(key) != "old-access-token") {
+                return 92;
+            }
+            captured_home = home;
+            const std::string config = ReadFile(captured_home / "config.toml");
+            if (config.find("wire_api = \"responses\"") == std::string::npos ||
+                config.find("base_url = \"https://console.runanywhere.ai/v1\"") ==
+                    std::string::npos ||
+                // The credential lives in the env var, never in the file.
+                config.find("old-access-token") != std::string::npos) {
+                return 93;
+            }
+            return 0;
+        });
+
+    if (status != 0 || !spawned) {
+        result.details = "launch did not wire Codex and pass its arguments through";
+        result.actual = std::to_string(status);
+        return result;
+    }
+    // The throwaway CODEX_HOME and both env vars are gone afterwards.
+    if (fs::exists(captured_home) || std::getenv("CODEX_HOME") != nullptr ||
+        std::getenv("WALLY_CODEX_API_KEY") != nullptr) {
+        result.details = "temporary CODEX_HOME or key env survived the launch";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+TestResult test_restores_env_when_spawn_throws() {
+    TestResult result;
+    result.test_name = "restores_env_when_spawn_throws";
+    TemporaryDirectory temporary;
+    Environment profile("WALLY_PROFILE_DIR", temporary.path().string().c_str());
+    Environment home("CODEX_HOME", "/some/original/home");
+    Environment key("WALLY_CODEX_API_KEY", "original-key");
+    std::string error;
+    if (!Seed(temporary.path(), Now() + 3600, &error)) {
+        result.details = error;
+        return result;
+    }
+
+    bool threw = false;
+    try {
+        const wally::account::ConsoleClient console = WhoAmIConsole();
+        static_cast<void>(wally::harness::LaunchCodexCloud(
+            "hosted-model", {}, console,
+            [](const std::string&, const std::vector<std::string>&) -> int {
+                throw std::runtime_error("synthetic spawn failure");
+            }));
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    const char* home_now = std::getenv("CODEX_HOME");
+    const char* key_now = std::getenv("WALLY_CODEX_API_KEY");
+    if (!threw || home_now == nullptr || std::string(home_now) != "/some/original/home" ||
+        key_now == nullptr || std::string(key_now) != "original-key") {
+        result.details = "Codex env did not restore after an exceptional child launch";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    TestSuite suite("wally_codex");
+    suite.add("build_config_names_key_env_and_responses",
+              test_build_config_names_key_env_and_responses);
+    suite.add("ephemeral_home_key_env_and_passthrough",
+              test_ephemeral_home_key_env_and_passthrough);
+    suite.add("restores_env_when_spawn_throws", test_restores_env_when_spawn_throws);
+    return suite.run(argc, argv);
+}


### PR DESCRIPTION
Adds `wally codex -m <model>`, the same shape as `wally opencode --cloud`: it
launches Codex wired to a signed-in hosted model, with the session verified
before anything spawns.

Codex reads its provider from `$CODEX_HOME/config.toml` rather than an env var,
so the launch writes a throwaway CODEX_HOME (removed afterwards) and passes the
key through the env var the config names (`env_key`) — the credential never
lands in a file or on argv. The provider talks the Responses API
(`wire_api = "responses"`).

Hosted-only for now: a local `wally serve` speaks chat/completions, not
responses, so there is no local Codex path yet. The gateway side of the
Responses API is tracked separately; this is the client wiring so Codex works
the moment the hosted endpoint serves it.

Tests: `BuildCodexConfig` (names the key env var, `wire_api = "responses"`, no
key in the file), the ephemeral CODEX_HOME + key-env + passthrough + cleanup,
and env restoration when the child throws. Full suite green on macOS arm64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `wally codex -m <id>` command for launching hosted Codex sessions with a selected model and additional arguments.
  * Added Codex to the “Editors & agents” help group.
  * Added cross-platform process launching and guidance when Codex is not installed.

* **Tests**
  * Added coverage for configuration generation, argument forwarding, temporary environment handling, cleanup, and error recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->