### PR TITLE
opencode: quote Windows spawn arguments

### DIFF
--- a/src/harness/opencode.cpp
+++ b/src/harness/opencode.cpp
@@ -86,7 +86,63 @@ void MissingOpenCode() {
     out::status_line("install it with `npm i -g opencode-ai`, then run this again");
 }
 
+#if defined(_WIN32)
+// Quote one argument so the child re-parses it as a single token. The _spawn*
+// family joins argv into a command line WITHOUT quoting, so an argument that
+// contains a space would otherwise arrive split in two. Rules per the
+// documented MSVCRT parser: double the run of backslashes that precedes a quote
+// (or the closing quote), and backslash-escape embedded quotes. The POSIX path
+// needs none of this -- execvp hands argv to the child verbatim.
+std::string QuoteWindowsArg(const std::string& arg) {
+    if (!arg.empty() && arg.find_first_of(" \t\n\v\"") == std::string::npos) {
+        return arg;
+    }
+    std::string quoted = "\"";
+    for (std::size_t i = 0;; ++i) {
+        std::size_t backslashes = 0;
+        while (i < arg.size() && arg[i] == '\\') {
+            ++i;
+            ++backslashes;
+        }
+        if (i == arg.size()) {
+            quoted.append(backslashes * 2, '\\');
+            break;
+        }
+        if (arg[i] == '"') {
+            quoted.append(backslashes * 2 + 1, '\\');
+            quoted.push_back('"');
+        } else {
+            quoted.append(backslashes, '\\');
+            quoted.push_back(arg[i]);
+        }
+    }
+    quoted.push_back('"');
+    return quoted;
+}
+#endif
+
 int Spawn(const std::string& executable, const std::vector<std::string>& arguments) {
+#if defined(_WIN32)
+    std::vector<std::string> owned;
+    owned.reserve(arguments.size() + 1);
+    owned.push_back(QuoteWindowsArg(executable));
+    for (const std::string& argument : arguments) {
+        owned.push_back(QuoteWindowsArg(argument));
+    }
+    std::vector<char*> argv;
+    argv.reserve(owned.size() + 1);
+    for (std::string& value : owned) {
+        argv.push_back(value.data());
+    }
+    argv.push_back(nullptr);
+
+    const intptr_t status = _spawnvp(_P_WAIT, executable.c_str(), argv.data());
+    if (status < 0) {
+        MissingOpenCode();
+        return 127;
+    }
+    return static_cast<int>(status);
+#else
     std::vector<std::string> owned;
     owned.reserve(arguments.size() + 1);
     owned.push_back(executable);
@@ -99,14 +155,6 @@ int Spawn(const std::string& executable, const std::vector<std::string>& argumen
     }
     argv.push_back(nullptr);
 
-#if defined(_WIN32)
-    const intptr_t status = _spawnvp(_P_WAIT, executable.c_str(), argv.data());
-    if (status < 0) {
-        MissingOpenCode();
-        return 127;
-    }
-    return static_cast<int>(status);
-#else
     const pid_t child = fork();
     if (child < 0) {
         out::error_line("could not start OpenCode");


### PR DESCRIPTION
`wally opencode`'s `Spawn` has the same Windows bug the codex review (#70) found:
the `_spawn*` family joins argv into a command line without quoting, so a
passthrough argument containing a space arrives at opencode split in two. On
POSIX `execvp` passes argv verbatim, so only the Windows branch is affected.

Adds the same MSVCRT-rule quoting used in the codex fix (double the backslash
run before a quote or the closing quote; backslash-escape embedded quotes),
applied to each argument on the Windows path only. Algorithm verified against
spaces, embedded quotes, trailing backslashes, and empty; POSIX path unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows process launching when executable paths or arguments contain spaces or quotation marks.
  * Preserved arguments correctly during application startup and command execution on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->