### PR TITLE
skill: name Wally in the trigger

### DIFF
--- a/skills/runanywhere/SKILL.md
+++ b/skills/runanywhere/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runanywhere
-description: Set up and use RunAnywhere from the terminal — install wally, sign in, pick a coding harness, run a model, check spend. Use when the user wants to get started with RunAnywhere, run a harness like opencode against a hosted or on-device model, or asks what their usage is.
+description: Set up and use RunAnywhere Wally from the terminal — install wally, sign in, pick a coding harness, run a model, check spend. Use when the user wants to get started with RunAnywhere or Wally, run a harness like opencode against a hosted or on-device model, or asks what their usage is.
 ---
 
 # RunAnywhere


### PR DESCRIPTION
The installer's get-started hint now says `"get me started with RunAnywhere Wally"`, so the skill's description includes Wally to match that trigger. No behavior change; still prod-only (plain `install.sh | sh`, no nightly) and codex is deliberately left out until the Responses API ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the skill description to refer to “RunAnywhere Wally” and recognize requests to get started with either RunAnywhere or Wally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->