### PR TITLE
release: wally 0.5.5

### DIFF
--- a/Formula/wally.rb
+++ b/Formula/wally.rb
@@ -3,15 +3,15 @@
 class Wally < Formula
   desc "Run language, speech and image models on your own machine"
   homepage "https://github.com/RunanywhereAI/wally"
-  version "0.5.4"
+  version "0.5.5"
   license "MIT"
 
   # macOS arm64 ships the Swift MLX host
   # (llama.cpp + ONNX + Sherpa + MLX). Linux is not in this cut.
   on_macos do
     on_arm do
-      url "https://github.com/RunanywhereAI/wally/releases/download/v0.5.4/wally-0.5.4-macos-arm64.tar.gz"
-      # Placeholder -- the v0.5.4 release has not published a wally-named asset
+      url "https://github.com/RunanywhereAI/wally/releases/download/v0.5.5/wally-0.5.5-macos-arm64.tar.gz"
+      # Placeholder -- the v0.5.5 release has not published a wally-named asset
       # yet. scripts/release/update-tap.sh re-stamps this from the real release
       # checksum; a stale value here fails brew install's own hash check
       # rather than installing something unverified.

--- a/versions.toml
+++ b/versions.toml
@@ -7,7 +7,7 @@
 
 [product]
 # wally's own release version; git tag is v<version> (auto-tag.yml reads it here).
-version = "0.5.4"
+version = "0.5.5"
 
 [sdk]
 # The published C++ desktop kit this tree builds against; bump the SHAs with it.


### PR DESCRIPTION
Bump product version to 0.5.5 in versions.toml and Formula/wally.rb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Releases**
  - Updated Wally to version 0.5.5.
  - The macOS ARM64 Homebrew installation now points to the Wally 0.5.5 release package, ensuring installations use the latest available version.
- **Maintenance**
  - Updated release metadata to consistently reflect version 0.5.5 across supported distribution channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->