### PR TITLE
cloud: survive a rate-limited console, and phrase console errors for the person reading them

### DIFF
--- a/scripts/build/build-mlx.sh
+++ b/scripts/build/build-mlx.sh
@@ -11,6 +11,15 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BUILD="${1:-${ROOT}/build}"
+# Absolute, because this script `cd`s to ${ROOT}/swift before it looks inside
+# ${BUILD} again. A relative build dir silently resolved against swift/ instead,
+# so libwally_plugins.a was "not found" even when it existed, and the empty
+# plugin array then tripped `set -u` on macOS bash 3.2 with the useless message
+# `plugin_ldflags[*]: unbound variable`.
+BUILD="$(cd "${BUILD}" 2>/dev/null && pwd)" || {
+    echo "error: build dir '${1:-${ROOT}/build}' does not exist - run cmake first" >&2
+    exit 1
+}
 
 KIT="${WALLY_SDK_KIT:-${CMAKE_PREFIX_PATH:-}}"
 KIT="${KIT%%:*}"
@@ -61,7 +70,7 @@ RUNANYWHERE_BUILD_MLX_DISTRIBUTION_FRAMEWORK=1 \
     -configuration Release \
     -derivedDataPath .build/xcode \
     HEADER_SEARCH_PATHS="\$(inherited) ${KIT}/include ${ROOT}/include" \
-    OTHER_LDFLAGS="${plugin_ldflags[*]} -L${BUILD} -lwally_bundle -lc++ ${flags[*]}" \
+    OTHER_LDFLAGS="${plugin_ldflags[*]:-} -L${BUILD} -lwally_bundle -lc++ ${flags[*]}" \
     >"${xcode_log}" 2>&1
 xcodebuild_status=$?
 set -e

--- a/src/account/console.cpp
+++ b/src/account/console.cpp
@@ -667,7 +667,8 @@ ConsoleClient::ConsoleClient(Transport transport)
     : transport_(transport ? std::move(transport) : Transport(DefaultTransport)) {}
 
 bool ConsoleClient::BeginAuthorization(const std::string& console_url, const std::string& hostname,
-                                       Authorization* authorization, std::string* error) const {
+                                       Authorization* authorization, std::string* error,
+                                       const std::function<void()>& on_retry) const {
     if (authorization == nullptr) {
         if (error != nullptr) {
             *error = "internal authorization error";
@@ -707,6 +708,9 @@ bool ConsoleClient::BeginAuthorization(const std::string& console_url, const std
         const int asked = response.retry_after_seconds();
         const int wait =
             asked >= 0 ? std::min(std::max(asked, 1), kRateLimitMaxWaitSeconds) : 1;
+        if (on_retry) {
+            on_retry();
+        }
         std::this_thread::sleep_for(std::chrono::seconds(wait));
     }
     if (response.status != 200) {
@@ -756,6 +760,14 @@ PollResult ConsoleClient::Poll(const std::string& console_url, const Authorizati
     }
     if (response.status != 200) {
         HttpError("poll", origin, response, error);
+        // A busy or briefly unavailable console has not denied anything, and the
+        // person may still be approving in the browser. Treat it as "still
+        // waiting" so the poll loop keeps going at its normal cadence instead of
+        // failing the whole login on one refusal (InferenceInfra#444). The loop
+        // is bounded by the authorization's own expiry, so this cannot spin.
+        if (response.status == 429 || response.status >= 500) {
+            return PollResult::Pending;
+        }
         return PollResult::Failed;
     }
 

--- a/src/account/console.cpp
+++ b/src/account/console.cpp
@@ -4,12 +4,14 @@
 #include <array>
 #include <cctype>
 #include <charconv>
+#include <cstdlib>
 #include <chrono>
 #include <cstdint>
 #include <limits>
 #include <map>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <thread>
 #include <utility>
 
 #if defined(_WIN32)
@@ -28,6 +30,18 @@ namespace {
 
 using Json = nlohmann::json;
 constexpr std::size_t kMaximumResponseBytes = 1024 * 1024;
+
+// The endpoint a call went to is internal detail: an ordinary person reading
+// "could not reach ... at https://inference.runanywhere.ai/api-dev" cannot act
+// on it, and `wally about` already stopped printing it. Name it only when
+// somebody deliberately pointed this binary elsewhere, which is the one case
+// where "which console answered" is the question being asked.
+inline void AppendEndpointIfOverridden(std::string* error, const std::string& url) {
+    const char* override_url = std::getenv("WALLY_CONSOLE_URL");
+    if (error != nullptr && override_url != nullptr && override_url[0] != '\0') {
+        *error += " (" + url + ")";
+    }
+}
 
 #if defined(_WIN32)
 
@@ -105,7 +119,7 @@ bool WinHttpTransport(const HttpRequest& input, HttpResponse* output, std::strin
     if (!Utf8ToWide(input.url, &url) || !Utf8ToWide(input.method, &method) ||
         url.size() > std::numeric_limits<DWORD>::max()) {
         if (error != nullptr) {
-            *error = "could not create the console HTTP request";
+            *error = "could not contact Wally Cloud";
         }
         return false;
     }
@@ -121,7 +135,7 @@ bool WinHttpTransport(const HttpRequest& input, HttpResponse* output, std::strin
         (components.nScheme != INTERNET_SCHEME_HTTP &&
          components.nScheme != INTERNET_SCHEME_HTTPS)) {
         if (error != nullptr) {
-            *error = "could not create the console HTTP request";
+            *error = "could not contact Wally Cloud";
         }
         return false;
     }
@@ -188,7 +202,7 @@ bool WinHttpTransport(const HttpRequest& input, HttpResponse* output, std::strin
         std::wstring token;
         if (!Utf8ToWide(input.bearer_token, &token)) {
             if (error != nullptr) {
-                *error = "could not create the console HTTP request";
+                *error = "could not contact Wally Cloud";
             }
             return false;
         }
@@ -197,7 +211,7 @@ bool WinHttpTransport(const HttpRequest& input, HttpResponse* output, std::strin
     if (headers.size() > std::numeric_limits<DWORD>::max() ||
         input.body.size() > std::numeric_limits<DWORD>::max()) {
         if (error != nullptr) {
-            *error = "could not create the console HTTP request";
+            *error = "could not contact Wally Cloud";
         }
         return false;
     }
@@ -210,7 +224,7 @@ bool WinHttpTransport(const HttpRequest& input, HttpResponse* output, std::strin
         !SetReceiveTimeout(request.get(), deadline, true) ||
         !WinHttpReceiveResponse(request.get(), nullptr)) {
         if (error != nullptr) {
-            *error = "could not reach the RunAnywhere console";
+            *error = "could not reach Wally Cloud - check your internet connection";
         }
         return false;
     }
@@ -222,7 +236,7 @@ bool WinHttpTransport(const HttpRequest& input, HttpResponse* output, std::strin
                              WINHTTP_NO_HEADER_INDEX) ||
         status < 100 || status > 599) {
         if (error != nullptr) {
-            *error = "could not reach the RunAnywhere console";
+            *error = "could not reach Wally Cloud - check your internet connection";
         }
         return false;
     }
@@ -262,7 +276,7 @@ bool WinHttpTransport(const HttpRequest& input, HttpResponse* output, std::strin
                              &received)) {
             output->body.clear();
             if (error != nullptr) {
-                *error = "could not reach the RunAnywhere console";
+                *error = "could not reach Wally Cloud - check your internet connection";
             }
             return false;
         }
@@ -273,7 +287,7 @@ bool WinHttpTransport(const HttpRequest& input, HttpResponse* output, std::strin
             received > kMaximumResponseBytes - output->body.size()) {
             output->body.clear();
             if (error != nullptr) {
-                *error = "console response exceeded the safety limit";
+                *error = "Wally Cloud sent an unexpectedly large response";
             }
             return false;
         }
@@ -438,8 +452,11 @@ bool DefaultTransport(const HttpRequest& input, HttpResponse* output, std::strin
             // Names the origin actually contacted: with WALLY_CONSOLE_URL unset
             // that is the production console, and a bare "could not reach the
             // console" reads as a local dev server nobody pointed us at.
-            *error = response.too_large ? "console response exceeded the safety limit"
-                                        : "could not reach the RunAnywhere console at " + input.url;
+            *error = response.too_large
+                         ? std::string("Wally Cloud sent an unexpectedly large response")
+                         : std::string(
+                               "could not reach Wally Cloud - check your internet connection");
+            AppendEndpointIfOverridden(error, input.url);
         }
         return false;
     }
@@ -453,19 +470,40 @@ void HttpError(const char* operation, const std::string& origin, const HttpRespo
     if (error == nullptr) {
         return;
     }
-    // Names which console answered: with WALLY_CONSOLE_URL unset that is
-    // production, and a bare "failed with HTTP 404" reads as a bug rather
-    // than as the wrong console having been asked.
-    *error = std::string("console ") + operation + " (" + origin + ") failed with HTTP " +
-             std::to_string(response.status);
-    // A 429 means overload, not a broken request. Tell the person how long the
-    // server asked them to wait, so "try again" is actionable rather than a
-    // guess.
-    if (response.status == 429) {
+    // Every console failure in this file is phrased here, so this is the one
+    // place that decides what a person reads when the cloud says no. It is
+    // written for them, not for us: a status line and an internal endpoint
+    // ("console refresh (https://.../api-dev) failed with HTTP 429") tells
+    // somebody trying to start a coding agent nothing they can act on.
+    const int status = response.status;
+    if (status == 429) {
+        // Not a broken request - overload. Say how long the server itself asked
+        // for, so "try again" is a fact rather than a guess.
         const int wait = response.retry_after_seconds();
-        *error += wait >= 0 ? "; the console is rate limiting, retry after " + std::to_string(wait) +
-                                  "s"
-                            : "; the console is rate limiting, wait a moment and retry";
+        *error = wait >= 0 ? "Wally Cloud is busy - try again in " + std::to_string(wait) + "s"
+                           : "Wally Cloud is busy - try again in a moment";
+    } else if (status == 401 || status == 403) {
+        *error = "your cloud session is no longer valid - run `wally login`";
+    } else if (status == 404) {
+        *error = "Wally Cloud has no such endpoint";
+    } else if (status >= 500) {
+        // The status stays on this one: the person cannot act on a 5xx either
+        // way, and it is the only thing support can work from.
+        *error = "Wally Cloud is temporarily unavailable - try again shortly (HTTP " +
+                 std::to_string(status) + ")";
+    } else {
+        // Nothing specific to say, so name the operation that failed and keep
+        // the status, which is the only part support can act on.
+        *error = std::string("Wally Cloud could not complete the ") + operation + " (HTTP " +
+                 std::to_string(status) + ")";
+    }
+    // The endpoint is worth naming in exactly two cases: the console denies the
+    // route exists (so the wrong console was probably asked), or somebody
+    // deliberately pointed this binary elsewhere. Otherwise it is internal
+    // detail, and `wally about` already stopped printing it.
+    const char* override_url = std::getenv("WALLY_CONSOLE_URL");
+    if (status == 404 || (override_url != nullptr && override_url[0] != '\0')) {
+        *error += " (" + origin + ")";
     }
 }
 
@@ -521,10 +559,8 @@ bool Send(const Transport& transport, HttpRequest request, HttpResponse* respons
           std::string* error) {
     if (!transport(request, response, error)) {
         if (error != nullptr && error->empty()) {
-            // Names the origin actually contacted: with WALLY_CONSOLE_URL unset
-            // that is the production console, and a plain "could not reach the
-            // console" reads as a local server that was never told about.
-            *error = "could not reach the RunAnywhere console at " + request.url;
+            *error = "could not reach Wally Cloud - check your internet connection";
+            AppendEndpointIfOverridden(error, request.url);
         }
         return false;
     }
@@ -650,10 +686,28 @@ bool ConsoleClient::BeginAuthorization(const std::string& console_url, const std
     contract::CliStartRequest request;
     request.client = contract::CliClient::kRcli;
     request.hostname = hostname;
+    // A 429 here means the console is BUSY, not that this request is wrong.
+    // `wally login` used to give up on the first refusal, so while a load test
+    // was driving the same console nobody could sign in at all, and the advice
+    // in the error ("wait a moment and retry") was left to the person to carry
+    // out by hand (InferenceInfra#444). Do the waiting here, for as long as the
+    // server asked, and only then fail with the same message as before.
+    constexpr int kRateLimitRetries = 3;
+    constexpr int kRateLimitMaxWaitSeconds = 5;
+    const HttpRequest start{"POST", origin + "/auth/cli/start", Json(request).dump(), {}};
     HttpResponse response;
-    if (!Send(transport_, {"POST", origin + "/auth/cli/start", Json(request).dump(), {}}, &response,
-              error)) {
-        return false;
+    for (int attempt = 0;; ++attempt) {
+        response = HttpResponse{};
+        if (!Send(transport_, start, &response, error)) {
+            return false;
+        }
+        if (response.status != 429 || attempt >= kRateLimitRetries) {
+            break;
+        }
+        const int asked = response.retry_after_seconds();
+        const int wait =
+            asked >= 0 ? std::min(std::max(asked, 1), kRateLimitMaxWaitSeconds) : 1;
+        std::this_thread::sleep_for(std::chrono::seconds(wait));
     }
     if (response.status != 200) {
         HttpError("authorization", origin, response, error);
@@ -734,7 +788,10 @@ PollResult ConsoleClient::Poll(const std::string& console_url, const Authorizati
 }
 
 bool ConsoleClient::Refresh(const std::string& console_url, const std::string& refresh_token,
-                            Grant* grant, std::string* error) const {
+                            Grant* grant, std::string* error, bool* unavailable) const {
+    if (unavailable != nullptr) {
+        *unavailable = false;
+    }
     if (grant == nullptr || !SessionTokenIsSafe(refresh_token)) {
         if (error != nullptr) {
             *error = "no refresh token is available";
@@ -754,6 +811,11 @@ bool ConsoleClient::Refresh(const std::string& console_url, const std::string& r
     }
     if (response.status != 200) {
         HttpError("refresh", origin, response, error);
+        // Same distinction as WhoAmI: a busy console has not told us this
+        // session is bad, only that it could not answer (InferenceInfra#444).
+        if (unavailable != nullptr) {
+            *unavailable = response.status == 429 || response.status >= 500;
+        }
         return false;
     }
     contract::GrantResponse parsed;
@@ -798,6 +860,13 @@ IdentityResult ConsoleClient::WhoAmI(const std::string& console_url,
     }
     if (response.status != 200) {
         HttpError("identity request", origin, response, error);
+        // A 429 or a 5xx says "not right now", not "this session is bad". Those
+        // are the two the console produces under load, and treating them as a
+        // bad session locked a signed-in person out of their own harness while
+        // a load test was running (InferenceInfra#444).
+        if (response.status == 429 || response.status >= 500) {
+            return IdentityResult::Unavailable;
+        }
         return IdentityResult::Failed;
     }
 

--- a/src/account/console.h
+++ b/src/account/console.h
@@ -139,7 +139,11 @@ struct Grant {
 };
 
 enum class PollResult { Pending, Approved, Denied, Expired, Failed };
-enum class IdentityResult { Ok, Unauthorized, Failed };
+/// `Unavailable` means the console could not be ASKED (it is rate limiting or
+/// down). It is not a disproof of the session held locally, and a caller that
+/// already has one may choose to go on using it. `Failed` stays "this did not
+/// work and the session cannot be trusted".
+enum class IdentityResult { Ok, Unauthorized, Failed, Unavailable };
 
 /// One served model as `/v1/models` advertises it. `context_window` is the
 /// input-token ceiling a coding agent reads to decide when to compact; 0 means
@@ -171,8 +175,10 @@ class ConsoleClient {
                             Authorization* authorization, std::string* error) const;
     PollResult Poll(const std::string& console_url, const Authorization& authorization,
                     Grant* grant, std::string* error) const;
+    /// `unavailable` is set true when the refresh failed because the console is
+    /// rate limiting or down (429/5xx) rather than because the session is bad.
     bool Refresh(const std::string& console_url, const std::string& refresh_token, Grant* grant,
-                 std::string* error) const;
+                 std::string* error, bool* unavailable = nullptr) const;
     IdentityResult WhoAmI(const std::string& console_url, const std::string& access_token,
                           Identity* identity, std::string* error) const;
     bool Revoke(const std::string& console_url, const std::string& access_token,

--- a/src/account/console.h
+++ b/src/account/console.h
@@ -171,8 +171,11 @@ class ConsoleClient {
    public:
     explicit ConsoleClient(Transport transport = {});
 
+    /// `on_retry` is called before each wait when the console is rate limiting,
+    /// so a command can tell the person it is retrying rather than look hung.
     bool BeginAuthorization(const std::string& console_url, const std::string& hostname,
-                            Authorization* authorization, std::string* error) const;
+                            Authorization* authorization, std::string* error,
+                            const std::function<void()>& on_retry = nullptr) const;
     PollResult Poll(const std::string& console_url, const Authorization& authorization,
                     Grant* grant, std::string* error) const;
     /// `unavailable` is set true when the refresh failed because the console is

--- a/src/commands/cmd_about.cpp
+++ b/src/commands/cmd_about.cpp
@@ -157,7 +157,10 @@ void register_about(CLI::App& app, GlobalOptions& options) {
                             RUNANYWHERE_IDL_SCHEMA_SHA256);
         row("platform", kPlatform);
         row("channel", channel);
-        row("console", console_url);
+        // The console URL is deliberately NOT printed here. It is an internal
+        // endpoint (today `/api-dev`), it means nothing to the person reading
+        // `wally about`, and it was shown twice. It stays in `--json` so
+        // support and tooling can still read it.
 
         heading(pal, "System");
         row("os", device.os_version.empty() ? "unknown" : device.os_version);
@@ -196,7 +199,6 @@ void register_about(CLI::App& app, GlobalOptions& options) {
         if (signed_in) {
             heading(pal, "Account");
             row("email", credentials.email);
-            row("console", credentials.console_url);
         }
         out::result_line("");
     });

--- a/src/commands/cmd_account.cpp
+++ b/src/commands/cmd_account.cpp
@@ -175,7 +175,8 @@ int Login(const std::string& requested_console, bool open_browser) {
 
     account::ConsoleClient client;
     account::Authorization authorization;
-    if (!client.BeginAuthorization(console_url, Hostname(), &authorization, &failure)) {
+    if (!client.BeginAuthorization(console_url, Hostname(), &authorization, &failure,
+                                   [] { out::status_line("server busy, retrying"); })) {
         out::error_line(failure);
         return 1;
     }
@@ -209,6 +210,13 @@ int Login(const std::string& requested_console, bool open_browser) {
     while (std::chrono::steady_clock::now() < deadline) {
         switch (client.Poll(console_url, authorization, &grant, &failure)) {
             case account::PollResult::Pending:
+                // Poll() reports a rate-limited console as Pending and leaves
+                // the reason in `failure`. Say so once rather than sitting
+                // silent, so a slow login does not look like a hang.
+                if (!failure.empty()) {
+                    out::status_line("server busy, retrying");
+                    failure.clear();
+                }
                 std::this_thread::sleep_for(std::chrono::seconds(authorization.interval));
                 continue;
             case account::PollResult::Denied:

--- a/src/harness/codex.cpp
+++ b/src/harness/codex.cpp
@@ -272,9 +272,19 @@ int LaunchCodexCloud(const std::string& model, const std::vector<std::string>& a
         out::error_line("not signed in - run `wally login`");
         return 1;
     }
-    if (!VerifyCloudSession(console, &credentials, nullptr, &error)) {
-        out::error_line("the signed-in cloud session did not check out: " + error);
-        return 1;
+    bool unverified = false;
+    if (!VerifyCloudSession(console, &credentials, nullptr, &error, &unverified)) {
+        if (!unverified) {
+            out::error_line("cannot use the cloud session: " + error);
+            return 1;
+        }
+        // The console could not be asked right now. That is not a disproof of
+        // the session already on disk, and refusing here locks a signed-in
+        // person out of their harness over a transient 429 (InferenceInfra#444).
+        // Go in on the stored session; the harness's own calls surface the real
+        // error if it is still there.
+        out::status_line("could not confirm the cloud session (" + error +
+                         ") - continuing on the stored session");
     }
 
     const std::string base_url = credentials.console_url + "/v1";

--- a/src/harness/harness.cpp
+++ b/src/harness/harness.cpp
@@ -267,7 +267,10 @@ long long EpochSeconds() {
 /// token for a new access token and persist it, so later commands in the same
 /// session do not pay for the refresh again.
 bool RefreshSession(const account::ConsoleClient& console, account::Credentials* credentials,
-                    std::string* error) {
+                    std::string* error, bool* unavailable) {
+    if (unavailable != nullptr) {
+        *unavailable = false;
+    }
     if (credentials->refresh_token.empty()) {
         if (error != nullptr) {
             *error = "the cloud session cannot be refreshed; run `wally login`";
@@ -275,7 +278,8 @@ bool RefreshSession(const account::ConsoleClient& console, account::Credentials*
         return false;
     }
     account::Grant grant;
-    if (!console.Refresh(credentials->console_url, credentials->refresh_token, &grant, error)) {
+    if (!console.Refresh(credentials->console_url, credentials->refresh_token, &grant, error,
+                         unavailable)) {
         return false;
     }
     credentials->access_token = grant.access_token;
@@ -308,28 +312,49 @@ bool ModelIdIsSafe(const std::string& id) {
 }
 
 bool VerifyCloudSession(const account::ConsoleClient& console, account::Credentials* credentials,
-                        std::string* email, std::string* error) {
+                        std::string* email, std::string* error, bool* unverified) {
+    if (unverified != nullptr) {
+        *unverified = false;
+    }
     if (credentials == nullptr) {
         if (error != nullptr) {
             *error = "internal cloud session error";
         }
         return false;
     }
-    if (credentials->access_token_expired(EpochSeconds()) &&
-        !RefreshSession(console, credentials, error)) {
-        return false;
+    // An EXPIRED token refreshes first, and that refresh is itself a console
+    // call that can be rate limited. This is the path a real user hits, because
+    // tokens expire hourly: the refresh 429'd and the launch was refused before
+    // the identity check below was ever reached (InferenceInfra#444).
+    if (credentials->access_token_expired(EpochSeconds())) {
+        bool refresh_unavailable = false;
+        if (!RefreshSession(console, credentials, error, &refresh_unavailable)) {
+            if (unverified != nullptr) {
+                *unverified = refresh_unavailable;
+            }
+            return false;
+        }
     }
     account::Identity identity;
     account::IdentityResult result =
         console.WhoAmI(credentials->console_url, credentials->access_token, &identity, error);
     if (result == account::IdentityResult::Unauthorized) {
-        if (!RefreshSession(console, credentials, error)) {
+        bool refresh_unavailable = false;
+        if (!RefreshSession(console, credentials, error, &refresh_unavailable)) {
+            if (unverified != nullptr) {
+                *unverified = refresh_unavailable;
+            }
             return false;
         }
         identity = account::Identity{};
         result = console.WhoAmI(credentials->console_url, credentials->access_token, &identity, error);
     }
     if (result != account::IdentityResult::Ok) {
+        // Separate "the console says this session is bad" from "the console
+        // could not be asked". Only the first should stop a launch.
+        if (unverified != nullptr) {
+            *unverified = result == account::IdentityResult::Unavailable;
+        }
         return false;
     }
     if (email != nullptr) {
@@ -436,17 +461,26 @@ bool Resolve(const std::string& model, Endpoint* endpoint, int preferred_port) {
         const account::ConsoleClient console;
         std::string email;
         std::string verify_error;
-        if (!VerifyCloudSession(console, &credentials, &email, &verify_error)) {
-            out::error_line(model +
-                            " is not on this machine, and the signed-in cloud session did not "
-                            "check out: " +
-                            verify_error);
-            out::status_line("run `wally login`, or `wally pull " + model + "` to run it here");
-            return false;
+        bool unverified = false;
+        if (!VerifyCloudSession(console, &credentials, &email, &verify_error, &unverified)) {
+            if (!unverified) {
+                out::error_line("cannot use " + model + ": " + verify_error);
+                out::status_line("run `wally login`, or `wally pull " + model +
+                                 "` to run it here");
+                return false;
+            }
+            // The console could not be ASKED - it is rate limiting or down.
+            // That is no disproof of the session already on disk, and refusing
+            // here locked every signed-in person out of their own harness while
+            // a load test ran against the same console (InferenceInfra#444).
+            // Go in on the stored session; the harness's own calls surface the
+            // real error if it is still there.
+            out::status_line("could not confirm the cloud session (" + verify_error +
+                             ") - continuing on the stored session");
         }
         base_url = credentials.console_url + "/v1";
         api_key = credentials.access_token;
-        out::status_line("using " + model + " as " + email);
+        out::status_line("using " + model + (email.empty() ? "" : " as " + email));
     }
 
     endpoint->base_url = base_url;

--- a/src/harness/harness.h
+++ b/src/harness/harness.h
@@ -46,8 +46,11 @@ bool ModelIdIsSafe(const std::string& id);
 /// On success `credentials` holds the (possibly refreshed, and already saved)
 /// session and `email` names who it verified as. `error` is set on failure.
 /// Exposed so the contract can be tested without a real console.
+/// `unverified` is set true when the session could not be CHECKED (the console
+/// is rate limiting or down) rather than found bad. A caller holding a
+/// signed-in session may proceed on it in that case.
 bool VerifyCloudSession(const account::ConsoleClient& console, account::Credentials* credentials,
-                        std::string* email, std::string* error);
+                        std::string* email, std::string* error, bool* unverified = nullptr);
 
 /// Points `endpoint` at `model`, starting a local server when the model is on
 /// this machine and confirming the signed-in console session for real —

--- a/src/harness/opencode.cpp
+++ b/src/harness/opencode.cpp
@@ -242,9 +242,19 @@ int LaunchOpenCodeCloud(const std::string& model, const std::vector<std::string>
         out::error_line("not signed in - run `wally login`");
         return 1;
     }
-    if (!VerifyCloudSession(console, &credentials, nullptr, &error)) {
-        out::error_line("the signed-in cloud session did not check out: " + error);
-        return 1;
+    bool unverified = false;
+    if (!VerifyCloudSession(console, &credentials, nullptr, &error, &unverified)) {
+        if (!unverified) {
+            out::error_line("cannot use the cloud session: " + error);
+            return 1;
+        }
+        // The console could not be asked right now. That is not a disproof of
+        // the session already on disk, and refusing here locks a signed-in
+        // person out of their harness over a transient 429 (InferenceInfra#444).
+        // Go in on the stored session; the harness's own calls surface the real
+        // error if it is still there.
+        out::status_line("could not confirm the cloud session (" + error +
+                         ") - continuing on the stored session");
     }
 
     const std::string base_url = credentials.console_url + "/v1";

--- a/tests/test_wally_account.cpp
+++ b/tests/test_wally_account.cpp
@@ -531,7 +531,7 @@ TestResult test_a_rate_limit_surfaces_its_retry_after() {
     std::string error;
     if (with_hint.BeginAuthorization("https://console.runanywhere.ai", "host", &authorization,
                                      &error) ||
-        error.find("retry after 30s") == std::string::npos) {
+        error.find("try again in 30s") == std::string::npos) {
         result.details = "a 429 with Retry-After did not surface the wait: " + error;
         return result;
     }
@@ -548,7 +548,7 @@ TestResult test_a_rate_limit_surfaces_its_retry_after() {
     error.clear();
     if (no_hint.BeginAuthorization("https://console.runanywhere.ai", "host", &authorization,
                                    &error) ||
-        error.find("rate limiting") == std::string::npos ||
+        error.find("busy") == std::string::npos ||
         error.find("soon") != std::string::npos) {
         result.details = "a 429 with a non-numeric Retry-After was mishandled: " + error;
         return result;

--- a/tests/test_wally_account.cpp
+++ b/tests/test_wally_account.cpp
@@ -764,6 +764,55 @@ TestResult test_usage_counters_survive_beyond_thirty_two_bits() {
     return result;
 }
 
+// A 429 mid-poll must not kill the login. `wally login` printed its code and
+// URL, then died on the first rate-limited poll while the person was still
+// approving in the browser (InferenceInfra#444).
+TestResult test_a_rate_limited_poll_keeps_waiting() {
+    TestResult result;
+    result.test_name = "a_rate_limited_poll_keeps_waiting";
+
+    int polls = 0;
+    wally::account::ConsoleClient client([&](const wally::account::HttpRequest& request,
+                                            wally::account::HttpResponse* response, std::string*) {
+        if (request.url.ends_with("/auth/cli/poll")) {
+            polls++;
+            if (polls == 1) {           // busy console on the first poll
+                response->status = 429;
+                return true;
+            }
+            response->status = 200;     // then the person approves
+            response->body = Json{{"status", "approved"},
+                                  {"access_token", "access-one"},
+                                  {"refresh_token", "refresh-one"},
+                                  {"email", "dev@example.test"},
+                                  {"expires_in", 3600}}
+                                 .dump();
+            return true;
+        }
+        return false;
+    });
+
+    wally::account::Authorization authorization;
+    authorization.request_code = "ABCD-EFGH";
+    authorization.poll_secret = "poll-secret";
+    wally::account::Grant grant;
+    std::string error;
+
+    if (client.Poll("https://console.runanywhere.ai", authorization, &grant, &error) !=
+        wally::account::PollResult::Pending) {
+        result.details = "a 429 poll must read as still-waiting, not a failed login: " + error;
+        return result;
+    }
+    if (client.Poll("https://console.runanywhere.ai", authorization, &grant, &error) !=
+            wally::account::PollResult::Approved ||
+        grant.access_token != "access-one") {
+        result.details = "the next poll should have completed the login";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -784,6 +833,7 @@ int main(int argc, char** argv) {
     suite.add("console_client_contract", test_console_client_contract);
     suite.add("console_errors_do_not_echo_secrets", test_console_errors_do_not_echo_secrets);
     suite.add("a_rate_limit_surfaces_its_retry_after", test_a_rate_limit_surfaces_its_retry_after);
+    suite.add("a_rate_limited_poll_keeps_waiting", test_a_rate_limited_poll_keeps_waiting);
     suite.add("console_rejects_header_injection", test_console_rejects_header_injection);
     suite.add("the_api_host_and_the_browser_host_stay_apart",
               test_the_api_host_and_the_browser_host_stay_apart);

--- a/tests/test_wally_harness.cpp
+++ b/tests/test_wally_harness.cpp
@@ -297,6 +297,151 @@ TestResult test_verify_cloud_session_accepts_real_session() {
     return result;
 }
 
+// A console that is merely RATE LIMITING must not read as a bad session. This
+// is InferenceInfra#444: a load test drove /v1/me to 429 and every signed-in
+// person was refused entry to their own harness, `wally login` included.
+TestResult test_verify_cloud_session_rate_limit_is_unverified_not_bad() {
+    TestResult result;
+    result.test_name = "verify_cloud_session_rate_limit_is_unverified_not_bad";
+    TemporaryDirectory temporary;
+    Environment profile("WALLY_PROFILE_DIR", temporary.path().string().c_str());
+    std::string error;
+    if (!Seed(temporary.path(), "good-access-token", "refresh-token", Now() + 3600, &error)) {
+        result.details = error;
+        return result;
+    }
+
+    wally::account::ConsoleClient console([&](const wally::account::HttpRequest&,
+                                             wally::account::HttpResponse* response, std::string*) {
+        response->status = 429;
+        return true;
+    });
+
+    wally::account::Credentials credentials;
+    if (!wally::account::Load(&credentials, &error)) {
+        result.details = error;
+        return result;
+    }
+
+    std::string email;
+    std::string verify_error;
+    bool unverified = false;
+    const bool ok =
+        wally::harness::VerifyCloudSession(console, &credentials, &email, &verify_error, &unverified);
+    if (ok) {
+        result.details = "a 429 is not a verified session";
+        return result;
+    }
+    if (!unverified) {
+        result.details =
+            "a rate-limited console must report the session as UNVERIFIED, not as bad - "
+            "otherwise the harness refuses a signed-in person over a transient 429";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+// The other half: a console that actually rejects the session must NOT be
+// reported as merely unverified, or a revoked key would walk straight into a
+// harness.
+TestResult test_verify_cloud_session_rejected_session_is_not_unverified() {
+    TestResult result;
+    result.test_name = "verify_cloud_session_rejected_session_is_not_unverified";
+    TemporaryDirectory temporary;
+    Environment profile("WALLY_PROFILE_DIR", temporary.path().string().c_str());
+    std::string error;
+    if (!Seed(temporary.path(), "revoked-access-token", "revoked-refresh-token", Now() + 3600,
+              &error)) {
+        result.details = error;
+        return result;
+    }
+
+    wally::account::ConsoleClient console([&](const wally::account::HttpRequest&,
+                                             wally::account::HttpResponse* response, std::string*) {
+        response->status = 401;
+        return true;
+    });
+
+    wally::account::Credentials credentials;
+    if (!wally::account::Load(&credentials, &error)) {
+        result.details = error;
+        return result;
+    }
+
+    std::string email;
+    std::string verify_error;
+    bool unverified = false;
+    const bool ok =
+        wally::harness::VerifyCloudSession(console, &credentials, &email, &verify_error, &unverified);
+    if (ok) {
+        result.details = "a 401 session must not verify";
+        return result;
+    }
+    if (unverified) {
+        result.details = "a rejected session must not be reported as merely unverified";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+// The path a real user actually hits: tokens expire hourly, so an expired
+// access token refreshes FIRST, and that refresh is itself a console call that
+// can be rate limited. The 429 fix on the identity check did not cover it, and
+// the launch was still refused before the identity check was ever reached
+// (InferenceInfra#444, reported against wally 0.5.6).
+TestResult test_verify_cloud_session_rate_limited_refresh_is_unverified_not_bad() {
+    TestResult result;
+    result.test_name = "verify_cloud_session_rate_limited_refresh_is_unverified_not_bad";
+    TemporaryDirectory temporary;
+    Environment profile("WALLY_PROFILE_DIR", temporary.path().string().c_str());
+    std::string error;
+    // Expired access token, so VerifyCloudSession refreshes before anything else.
+    if (!Seed(temporary.path(), "expired-access-token", "refresh-token", Now() - 1, &error)) {
+        result.details = error;
+        return result;
+    }
+
+    bool asked_refresh = false;
+    wally::account::ConsoleClient console([&](const wally::account::HttpRequest& request,
+                                             wally::account::HttpResponse* response, std::string*) {
+        if (request.url.ends_with("/auth/cli/refresh")) {
+            asked_refresh = true;
+        }
+        response->status = 429;
+        return true;
+    });
+
+    wally::account::Credentials credentials;
+    if (!wally::account::Load(&credentials, &error)) {
+        result.details = error;
+        return result;
+    }
+
+    std::string email;
+    std::string verify_error;
+    bool unverified = false;
+    const bool ok =
+        wally::harness::VerifyCloudSession(console, &credentials, &email, &verify_error, &unverified);
+    if (ok) {
+        result.details = "a rate-limited refresh is not a verified session";
+        return result;
+    }
+    if (!asked_refresh) {
+        result.details = "an expired token must attempt a refresh first";
+        return result;
+    }
+    if (!unverified) {
+        result.details =
+            "a rate-limited REFRESH must report the session as UNVERIFIED, not as bad - this is "
+            "the path that still refused the harness after the identity check was fixed";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -312,5 +457,11 @@ int main(int argc, char** argv) {
               test_verify_cloud_session_refreshes_and_reverifies);
     suite.add("verify_cloud_session_accepts_real_session",
               test_verify_cloud_session_accepts_real_session);
+    suite.add("verify_cloud_session_rate_limit_is_unverified_not_bad",
+              test_verify_cloud_session_rate_limit_is_unverified_not_bad);
+    suite.add("verify_cloud_session_rejected_session_is_not_unverified",
+              test_verify_cloud_session_rejected_session_is_not_unverified);
+    suite.add("verify_cloud_session_rate_limited_refresh_is_unverified_not_bad",
+              test_verify_cloud_session_rate_limited_refresh_is_unverified_not_bad);
     return suite.run(argc, argv);
 }


### PR DESCRIPTION
Fixes InferenceInfra#444. While a load test was driving the dev console to 429s, nobody could start a harness and nobody could sign in — a transient rate limit was being treated as a broken session.

## Letting a busy console through

`IdentityResult` gains `Unavailable`. A 429 or 5xx means the console could not be *asked*; it is not a disproof of the session already on disk. `VerifyCloudSession` reports that separately from "this session is bad", and all three launch paths continue on the stored session instead of refusing. A genuinely rejected session (401 that survives a refresh) still stops the launch.

Two paths needed it, not one. The identity check was the obvious half. The half that actually bit people is the **refresh**: access tokens expire hourly, so an expired token refreshes *first*, and that refresh is its own console call. It 429'd and the launch was refused before the identity check was ever reached — which is why the first fix appeared to work and then failed again with a different message.

`wally login` had the same problem with nothing to fall back on, so `BeginAuthorization` now retries up to three times, waiting as long as the server's `Retry-After` asks (capped at 5s), instead of giving up on the first refusal.

## Errors written for the person reading them

Every console failure was phrased in one place, and it read like a stack trace: `console refresh (https://inference.runanywhere.ai/api-dev) failed with HTTP 429`. Now:

| | |
|---|---|
| 429 | `Wally Cloud is busy - try again in 30s` |
| 401/403 | `your cloud session is no longer valid - run \`wally login\`` |
| 404 | `Wally Cloud has no such endpoint` |
| 5xx | `Wally Cloud is temporarily unavailable - try again shortly (HTTP 503)` |
| offline | `could not reach Wally Cloud - check your internet connection` |

The endpoint is no longer printed. It survives in exactly two cases where it is the answer rather than noise: a 404, where the wrong console is the likely diagnosis, and when `WALLY_CONSOLE_URL` is set, where somebody deliberately pointed the binary elsewhere. That is the same reasoning as the old comment, applied without putting an internal URL in front of a user.

The status stays on 5xx and on unknown failures. A person cannot act on either, and it is the only thing support can work from — `console_errors_do_not_echo_secrets` already guarantees a 500 keeps its status and never echoes the body, and that guarantee is untouched.

`wally about` stops printing the console URL for the same reason. It is still in `--json`.

## Build script

`build-mlx.sh` `cd`s to `swift/` before it looks inside `${BUILD}` again, so a relative build dir resolved against the wrong place, missed `libwally_plugins.a`, and the empty array then tripped `set -u` on macOS bash 3.2 with `plugin_ldflags[*]: unbound variable`. `BUILD` is absolutised at the top, and the array read is guarded so an empty one is not an error.

## Tests

78 pass across all seven binaries. Three new:

- a 429 on the identity check reports UNVERIFIED, not a bad session
- a 401 still reports a bad session, so a revoked key cannot walk into a harness
- a 429 on the **refresh** reports UNVERIFIED — the path that still refused after the identity check was fixed

Break tests, both quoted red then green: neutering the 429 mapping fails the identity guard; neutering the refresh classification fails the refresh guard; restoring gives 9/9.

Two existing expectations in `test_wally_account` moved to the new wording. Their intent is unchanged — the wait is still surfaced, a non-numeric `Retry-After` is still not echoed, and the secrets guarantee is untouched.

Built and installed locally as a dev-channel binary, and the reported command was run against the still-rate-limited console: the harness now opens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary Wally Cloud rate limits and outages during sign-in and session checks.
  - Sessions can continue using stored credentials when verification is temporarily unavailable, while invalid sessions are still rejected.
  - Added retry handling for rate-limited authorization requests and polling.
  - Updated error messages with clearer status details and retry guidance.

- **Updates**
  - Console endpoint details are no longer shown in standard `about` text output, but remain available in JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->