### PR TITLE
release: wally 0.5.7

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -7,7 +7,7 @@
 
 [product]
 # wally's own release version; git tag is v<version> (auto-tag.yml reads it here).
-version = "0.5.6"
+version = "0.5.7"
 
 [sdk]
 # The published C++ desktop kit this tree builds against; bump the SHAs with it.


### PR DESCRIPTION
Cuts 0.5.7 for the fixes merged in #88.

- a rate-limited console (429) no longer refuses a harness launch — covers the identity check, the token refresh, and the generic resolve path `wally claude-code` uses
- `wally login` survives a 429: the start call retries honouring `Retry-After`, and a rate-limited poll counts as "still waiting" instead of failing the login
- console errors are written for the person reading them ("Wally Cloud is busy - try again in 30s"), and no longer print the internal endpoint
- `server busy, retrying` is shown while waiting, so a slow login does not look like a hang
- `wally about` no longer prints the console URL (still in `--json`)
- `build-mlx.sh` accepts a relative build dir instead of failing with `plugin_ldflags[*]: unbound variable` on macOS bash 3.2

Version only; the code is already on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the product release version from 0.5.6 to 0.5.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->