### PR TITLE
account: move the CLI control-plane paths under /v1/auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,9 +71,9 @@ Do not wrap protobuf in OpenAPI merely to change protocol names. When Wally only
 transports SDK-owned bytes, protobuf generation and `SCHEMA_LOCK` satisfy this
 rule. When Wally directly owns an HTTP call, the OpenAPI requirement applies.
 
-The console's six CLI calls (`/auth/cli/{start,poll,refresh,revoke}`, `/v1/me`,
-`/v1/cli/usage`) follow this. `contracts/wally-cli-v1.openapi.json` is the pinned
-artifact, extracted from InferenceInfra's `control-plane-v1.openapi.json` by
+The console's six CLI calls (`/v1/auth/cli/{start,poll,refresh,revoke}`,
+`/v1/auth/me`, `/v1/cli/usage`) follow this.
+`contracts/wally-cli-v1.openapi.json` is the pinned artifact, extracted from InferenceInfra's `control-plane-v1.openapi.json` by
 `contracts/extract-cli-contract.py`. `contracts/generate_console_binding.py`
 turns it into `src/account/console_contract.h` (typed requests and responses,
 DO NOT EDIT), which `console.cpp` uses instead of hand-built JSON. Requests
@@ -107,11 +107,23 @@ or a retired MetalRT / hardcoded catalog.
 asks for a code, a browser the person already trusts approves it, and the
 terminal collects a key. No password ever reaches the CLI.
 
-The four endpoints it calls are **not ours to rename**: an installed binary
-talks to whatever the console deploys, so a field or path change breaks every
-copy in the wild. They are `POST /auth/cli/start`, `/auth/cli/poll`,
-`/auth/cli/refresh`, and `GET /v1/me`. The console side has a test that reads
-`src/account/console.cpp` directly and fails if the two drift.
+The four endpoints it calls are `POST /v1/auth/cli/start`, `/v1/auth/cli/poll`,
+`/v1/auth/cli/refresh`, and `GET /v1/auth/me`. Renaming one is expensive, not
+forbidden: an installed binary talks to whatever the console deploys, so every
+copy in the wild 404s the moment the API stops serving the old path. They were
+renamed once, by InferenceInfra#484, and what made it safe was the order —
+the CLI release was published first, and three people held the binary. That
+stops being affordable the day a customer holds it.
+
+They are declared once each, at the top of `src/account/console.cpp`. Add a
+control-plane call by naming its path there, never as a literal at the call
+site.
+
+The console side pins these paths too, in
+`api/tests/fixtures/rcli_console_contract.json`, and checks them against its own
+OpenAPI document. That fixture is captured from a frozen commit of this file, so
+it does not track this repo — a rename here and a rename there are two separate
+pieces of work, and theirs goes last.
 
 Two secrets do different jobs. `request_code` is public and names the attempt;
 `poll_secret` proves the process collecting the grant is the one that started

--- a/src/account/console.cpp
+++ b/src/account/console.cpp
@@ -31,6 +31,21 @@ namespace {
 using Json = nlohmann::json;
 constexpr std::size_t kMaximumResponseBytes = 1024 * 1024;
 
+// Every control-plane path the CLI calls, declared once. They were literals at
+// the six call sites until InferenceInfra#484 renamed five of them at once and
+// a path spelled out in six places became the obvious way to miss one.
+//
+// The base URL carries the deployment prefix (`/api-dev` for development); a
+// path here never does.
+constexpr char kAuthStartPath[] = "/v1/auth/cli/start";
+constexpr char kAuthPollPath[] = "/v1/auth/cli/poll";
+constexpr char kAuthRefreshPath[] = "/v1/auth/cli/refresh";
+constexpr char kAuthRevokePath[] = "/v1/auth/cli/revoke";
+constexpr char kIdentityPath[] = "/v1/auth/me";
+// Not renamed by #484, and not to be tidied into /v1/console/usage: that is a
+// different endpoint belonging to the console.
+constexpr char kUsagePath[] = "/v1/cli/usage";
+
 // The endpoint a call went to is internal detail: an ordinary person reading
 // "could not reach ... at https://inference.runanywhere.ai/api-dev" cannot act
 // on it, and `wally about` already stopped printing it. Name it only when
@@ -681,7 +696,7 @@ bool ConsoleClient::BeginAuthorization(const std::string& console_url, const std
     }
     // The client value is the contract enum, whose only member serializes to
     // "rcli" -- InferenceInfra's CliClient StrEnum recognizes exactly that, and
-    // sending anything else 422s /auth/cli/start. Renaming the wire value needs
+    // sending anything else 422s /v1/auth/cli/start. Renaming the wire value needs
     // a coordinated InferenceInfra change (add "wally" to the enum, re-vendor
     // this contract), which is why it is pinned here rather than free text.
     contract::CliStartRequest request;
@@ -695,7 +710,7 @@ bool ConsoleClient::BeginAuthorization(const std::string& console_url, const std
     // server asked, and only then fail with the same message as before.
     constexpr int kRateLimitRetries = 3;
     constexpr int kRateLimitMaxWaitSeconds = 5;
-    const HttpRequest start{"POST", origin + "/auth/cli/start", Json(request).dump(), {}};
+    const HttpRequest start{"POST", origin + kAuthStartPath, Json(request).dump(), {}};
     HttpResponse response;
     for (int attempt = 0;; ++attempt) {
         response = HttpResponse{};
@@ -754,7 +769,7 @@ PollResult ConsoleClient::Poll(const std::string& console_url, const Authorizati
     request.request_code = authorization.request_code;
     request.poll_secret = authorization.poll_secret;
     HttpResponse response;
-    if (!Send(transport_, {"POST", origin + "/auth/cli/poll", Json(request).dump(), {}}, &response,
+    if (!Send(transport_, {"POST", origin + kAuthPollPath, Json(request).dump(), {}}, &response,
               error)) {
         return PollResult::Failed;
     }
@@ -817,7 +832,7 @@ bool ConsoleClient::Refresh(const std::string& console_url, const std::string& r
     contract::CliRefreshRequest request;
     request.refresh_token = refresh_token;
     HttpResponse response;
-    if (!Send(transport_, {"POST", origin + "/auth/cli/refresh", Json(request).dump(), {}},
+    if (!Send(transport_, {"POST", origin + kAuthRefreshPath, Json(request).dump(), {}},
               &response, error)) {
         return false;
     }
@@ -861,7 +876,7 @@ IdentityResult ConsoleClient::WhoAmI(const std::string& console_url,
         return IdentityResult::Failed;
     }
     HttpResponse response;
-    if (!Send(transport_, {"GET", origin + "/v1/me", {}, access_token}, &response, error)) {
+    if (!Send(transport_, {"GET", origin + kIdentityPath, {}, access_token}, &response, error)) {
         return IdentityResult::Failed;
     }
     if (response.status == 401) {
@@ -1016,7 +1031,7 @@ IdentityResult ConsoleClient::FetchUsage(const std::string& console_url,
     // One read for the whole report: a terminal draws it in a single pass, and
     // three round-trips would only give it three chances to print parts that
     // disagree about when they were taken.
-    std::string url = origin + "/v1/cli/usage?days=" + std::to_string(std::clamp(query.days, 1, 365)) +
+    std::string url = origin + kUsagePath + "?days=" + std::to_string(std::clamp(query.days, 1, 365)) +
                       "&limit=" + std::to_string(std::clamp(query.limit, 1, 200));
     if (!query.model.empty()) {
         url += "&model=" + QueryEscape(query.model);
@@ -1129,7 +1144,7 @@ bool ConsoleClient::Revoke(const std::string& console_url, const std::string& ac
     contract::CliRefreshRequest request;
     request.refresh_token = refresh_token;
     HttpResponse response;
-    if (!Send(transport_, {"POST", origin + "/auth/cli/revoke", Json(request).dump(), access_token},
+    if (!Send(transport_, {"POST", origin + kAuthRevokePath, Json(request).dump(), access_token},
               &response, error)) {
         return false;
     }

--- a/src/account/credentials.cpp
+++ b/src/account/credentials.cpp
@@ -42,10 +42,11 @@ using Json = nlohmann::json;
 // they replace was one constant doing both, and it broke every command that
 // talks to the console.
 //
-// The API is the control plane — /auth/cli/start, /auth/cli/poll,
-// /auth/cli/refresh, /v1/me, /v1/cli/* — and it is served by Cloud Run. The web
-// console is the page a person approves a sign-in on, and it is served by
-// Railway. Measured 2026-09-04:
+// The API is the control plane — /v1/auth/cli/start, /v1/auth/cli/poll,
+// /v1/auth/cli/refresh, /v1/auth/me, /v1/cli/* — and it is served by Cloud Run.
+// The web console is the page a person approves a sign-in on, and it is served
+// by Railway. Measured 2026-09-04, before InferenceInfra#484 moved the auth
+// paths under /v1/auth, so the paths below are the ones that answered then:
 //
 //   inference.runanywhere.ai  /auth/cli/start 422  /v1/me 405  Google Frontend
 //   console.runanywhere.ai    /auth/cli/start 404  /v1/me 404  railway-hikari
@@ -64,7 +65,7 @@ constexpr const char* kProductionConsoleApi = "https://inference.runanywhere.ai"
 // The raw Railway name is here because it is what the control plane actually
 // hands out today:
 //
-//   POST https://inference.runanywhere.ai/auth/cli/start
+//   POST https://inference.runanywhere.ai/v1/auth/cli/start
 //     -> verification_url: https://runanywhere-frontend-production.up.railway.app/cloud/cli?code=...
 //
 // Trusting only the custom domain would refuse every real sign-in. Delete the
@@ -140,7 +141,7 @@ struct ParsedUrl {
 /// and therefore reaches different code than any real client does.
 ///
 /// A query or fragment is still refused. Every caller builds an endpoint by
-/// appending to this string, and `?a=1` + `/v1/me` is not a URL.
+/// appending to this string, and `?a=1` + `/v1/auth/me` is not a URL.
 bool NormalizeBasePath(const std::string& suffix, std::string* base_path) {
     if (suffix.empty() || suffix == "/") {
         base_path->clear();

--- a/src/account/credentials.h
+++ b/src/account/credentials.h
@@ -20,7 +20,7 @@ struct Credentials {
 };
 
 /// The console API used when neither a login flag nor WALLY_CONSOLE_URL is set.
-/// This is the control plane — `/auth/cli/*`, `/v1/me`, `/v1/cli/*` — and it is
+/// This is the control plane — `/v1/auth/cli/*`, `/v1/auth/me`, `/v1/cli/*` — and it is
 /// not the host a person approves a sign-in on. See `TrustedBrowserOrigin`.
 std::string DefaultConsoleUrl();
 

--- a/tests/test_account_cli.py
+++ b/tests/test_account_cli.py
@@ -96,7 +96,7 @@ class ConsoleHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         body = self.read_json()
         self.requests.append(("POST", self.path, self.headers.get("Authorization"), body))
-        if self.path == "/auth/cli/start":
+        if self.path == "/v1/auth/cli/start":
             self.reply(
                 200,
                 {
@@ -107,7 +107,7 @@ class ConsoleHandler(BaseHTTPRequestHandler):
                     "interval": 1,
                 },
             )
-        elif self.path == "/auth/cli/poll":
+        elif self.path == "/v1/auth/cli/poll":
             self.reply(
                 200,
                 {
@@ -118,14 +118,14 @@ class ConsoleHandler(BaseHTTPRequestHandler):
                     "expires_in": 3600,
                 },
             )
-        elif self.path == "/auth/cli/revoke":
+        elif self.path == "/v1/auth/cli/revoke":
             self.reply(204)
         else:
             self.reply(404, {"error": "unknown path"})
 
     def do_GET(self):
         self.requests.append(("GET", self.path, self.headers.get("Authorization"), None))
-        if self.path == "/v1/me":
+        if self.path == "/v1/auth/me":
             self.reply(200, {"email": EMAIL})
         elif self.path.startswith("/v1/cli/usage"):
             body = dict(USAGE_BODY)
@@ -254,9 +254,9 @@ def main():
                 raise AssertionError("logout did not remove the local session")
 
         expected = [
-            ("POST", "/auth/cli/start", None),
-            ("POST", "/auth/cli/poll", None),
-            ("GET", "/v1/me", f"Bearer {ACCESS_TOKEN}"),
+            ("POST", "/v1/auth/cli/start", None),
+            ("POST", "/v1/auth/cli/poll", None),
+            ("GET", "/v1/auth/me", f"Bearer {ACCESS_TOKEN}"),
             # One read per invocation. The windows are totalled server-side, so
             # `days` and `limit` are held at the minimum the route accepts —
             # nothing below the balance renders `totals`, `timeline` or `recent`.
@@ -264,7 +264,7 @@ def main():
             ("GET", "/v1/cli/usage?days=1&limit=1", f"Bearer {ACCESS_TOKEN}"),
             ("GET", "/v1/cli/usage?days=1&limit=1", f"Bearer {ACCESS_TOKEN}"),
             ("GET", "/v1/cli/usage?days=1&limit=1", f"Bearer {ACCESS_TOKEN}"),
-            ("POST", "/auth/cli/revoke", f"Bearer {ACCESS_TOKEN}"),
+            ("POST", "/v1/auth/cli/revoke", f"Bearer {ACCESS_TOKEN}"),
         ]
         actual = [(method, path, authorization) for method, path, authorization, _ in ConsoleHandler.requests]
         if actual != expected:
@@ -272,12 +272,12 @@ def main():
         # Looked up by path, not by index: a new call anywhere in the flow
         # renumbers the list and would otherwise silently assert the wrong body.
         bodies = {path: body for _, path, _, body in ConsoleHandler.requests}
-        if bodies["/auth/cli/poll"] != {
+        if bodies["/v1/auth/cli/poll"] != {
             "request_code": "ABCD-EFGH",
             "poll_secret": "poll-secret",
         }:
             raise AssertionError("poll request did not use the server-issued secret")
-        if bodies["/auth/cli/revoke"] != {"refresh_token": REFRESH_TOKEN}:
+        if bodies["/v1/auth/cli/revoke"] != {"refresh_token": REFRESH_TOKEN}:
             raise AssertionError("logout did not request refresh-token revocation")
     finally:
         server.shutdown()

--- a/tests/test_wally_account.cpp
+++ b/tests/test_wally_account.cpp
@@ -386,7 +386,7 @@ TestResult test_console_client_contract() {
     wally::account::Transport transport = [&](const wally::account::HttpRequest& request,
                                              wally::account::HttpResponse* response, std::string*) {
         requests.push_back(request);
-        if (request.url.ends_with("/auth/cli/start")) {
+        if (request.url.ends_with("/v1/auth/cli/start")) {
             response->status = 200;
             response->body =
                 Json{{"request_code", "ABCD-EFGH"},
@@ -395,7 +395,7 @@ TestResult test_console_client_contract() {
                      {"expires_in", 300},
                      {"interval", 1}}
                     .dump();
-        } else if (request.url.ends_with("/auth/cli/poll")) {
+        } else if (request.url.ends_with("/v1/auth/cli/poll")) {
             response->status = 200;
             response->body = polls++ == 0 ? Json{{"status", "pending"}}.dump()
                                           : Json{{"status", "approved"},
@@ -404,16 +404,16 @@ TestResult test_console_client_contract() {
                                                  {"email", "dev@example.test"},
                                                  {"expires_in", 3600}}
                                                 .dump();
-        } else if (request.url.ends_with("/auth/cli/refresh")) {
+        } else if (request.url.ends_with("/v1/auth/cli/refresh")) {
             response->status = 200;
             response->body = Json{{"access_token", "access-two"},
                                   {"refresh_token", "refresh-two"},
                                   {"expires_in", 3600}}
                                  .dump();
-        } else if (request.url.ends_with("/v1/me")) {
+        } else if (request.url.ends_with("/v1/auth/me")) {
             response->status = 200;
             response->body = Json{{"email", "dev@example.test"}}.dump();
-        } else if (request.url.ends_with("/auth/cli/revoke")) {
+        } else if (request.url.ends_with("/v1/auth/cli/revoke")) {
             response->status = 204;
         } else {
             return false;
@@ -579,12 +579,12 @@ TestResult test_console_rejects_header_injection() {
     wally::account::ConsoleClient client([](const wally::account::HttpRequest& request,
                                            wally::account::HttpResponse* response, std::string*) {
         response->status = 200;
-        if (request.url.ends_with("/auth/cli/poll")) {
+        if (request.url.ends_with("/v1/auth/cli/poll")) {
             response->body = Json{{"status", "approved"},
                                   {"access_token", "safe\r\nX-Injected: yes"},
                                   {"refresh_token", "refresh-token"}}
                                  .dump();
-        } else if (request.url.ends_with("/auth/cli/start")) {
+        } else if (request.url.ends_with("/v1/auth/cli/start")) {
             response->body = Json{{"request_code", "ABCD\nEFGH"},
                                   {"poll_secret", "poll-secret"},
                                   {"verification_url", "https://console.runanywhere.ai/device"}}
@@ -618,7 +618,8 @@ TestResult test_console_rejects_header_injection() {
 
 // The API host and the browser approval host are two deployments. Collapsing
 // them, or pointing the API at the console's Railway host, is the regression
-// this pins: measured 2026-09-04, console.runanywhere.ai answers
+// this pins: measured 2026-09-04, before InferenceInfra#484 moved the auth
+// paths under /v1/auth, console.runanywhere.ai answered the then-current
 // /auth/cli/start and /v1/me with 404 and its own SPA HTML, while
 // inference.runanywhere.ai answers 422 and 405 — the endpoints rejecting a bad
 // body and a wrong verb, which is how you know they exist.
@@ -632,12 +633,12 @@ TestResult test_the_api_host_and_the_browser_host_stay_apart() {
     const std::vector<std::string> browser = wally::account::TrustedBrowserOrigins(api);
 
     if (api == "https://console.runanywhere.ai") {
-        result.details = "the API default is the web console, which serves no /auth/cli or /v1 route";
+        result.details = "the API default is the web console, which serves no /v1/auth/cli or /v1 route";
         result.actual = api;
         return result;
     }
     if (api != "https://inference.runanywhere.ai") {
-        result.details = "the API default moved; confirm the new host serves /auth/cli/* and /v1/me";
+        result.details = "the API default moved; confirm the new host serves /v1/auth/cli/* and /v1/auth/me";
         result.actual = api;
         return result;
     }
@@ -774,7 +775,7 @@ TestResult test_a_rate_limited_poll_keeps_waiting() {
     int polls = 0;
     wally::account::ConsoleClient client([&](const wally::account::HttpRequest& request,
                                             wally::account::HttpResponse* response, std::string*) {
-        if (request.url.ends_with("/auth/cli/poll")) {
+        if (request.url.ends_with("/v1/auth/cli/poll")) {
             polls++;
             if (polls == 1) {           // busy console on the first poll
                 response->status = 429;

--- a/tests/test_wally_codex.cpp
+++ b/tests/test_wally_codex.cpp
@@ -88,7 +88,7 @@ wally::account::ConsoleClient WhoAmIConsole() {
     return wally::account::ConsoleClient(
         [](const wally::account::HttpRequest& request, wally::account::HttpResponse* response,
            std::string*) {
-            if (!request.url.ends_with("/v1/me")) {
+            if (!request.url.ends_with("/v1/auth/me")) {
                 return false;
             }
             response->status = 200;

--- a/tests/test_wally_harness.cpp
+++ b/tests/test_wally_harness.cpp
@@ -206,7 +206,7 @@ TestResult test_verify_cloud_session_refreshes_and_reverifies() {
     bool verified_with_new_token = false;
     wally::account::ConsoleClient console([&](const wally::account::HttpRequest& request,
                                              wally::account::HttpResponse* response, std::string*) {
-        if (request.url.ends_with("/auth/cli/refresh")) {
+        if (request.url.ends_with("/v1/auth/cli/refresh")) {
             refreshed = true;
             response->status = 200;
             response->body = Json{{"access_token", "new-access-token"},
@@ -215,7 +215,7 @@ TestResult test_verify_cloud_session_refreshes_and_reverifies() {
                                  .dump();
             return true;
         }
-        if (request.url.ends_with("/v1/me")) {
+        if (request.url.ends_with("/v1/auth/me")) {
             verified_with_new_token = request.bearer_token == "new-access-token";
             response->status = 200;
             response->body = Json{{"email", "developer@example.test"}}.dump();
@@ -267,11 +267,11 @@ TestResult test_verify_cloud_session_accepts_real_session() {
     bool refresh_called = false;
     wally::account::ConsoleClient console([&](const wally::account::HttpRequest& request,
                                              wally::account::HttpResponse* response, std::string*) {
-        if (request.url.ends_with("/auth/cli/refresh")) {
+        if (request.url.ends_with("/v1/auth/cli/refresh")) {
             refresh_called = true;
             return false;
         }
-        if (request.url.ends_with("/v1/me") && request.bearer_token == "real-access-token") {
+        if (request.url.ends_with("/v1/auth/me") && request.bearer_token == "real-access-token") {
             response->status = 200;
             response->body = Json{{"email", "developer@example.test"}}.dump();
             return true;
@@ -298,8 +298,9 @@ TestResult test_verify_cloud_session_accepts_real_session() {
 }
 
 // A console that is merely RATE LIMITING must not read as a bad session. This
-// is InferenceInfra#444: a load test drove /v1/me to 429 and every signed-in
-// person was refused entry to their own harness, `wally login` included.
+// is InferenceInfra#444: a load test drove the identity route to 429 and every
+// signed-in person was refused entry to their own harness, `wally login`
+// included.
 TestResult test_verify_cloud_session_rate_limit_is_unverified_not_bad() {
     TestResult result;
     result.test_name = "verify_cloud_session_rate_limit_is_unverified_not_bad";
@@ -406,7 +407,7 @@ TestResult test_verify_cloud_session_rate_limited_refresh_is_unverified_not_bad(
     bool asked_refresh = false;
     wally::account::ConsoleClient console([&](const wally::account::HttpRequest& request,
                                              wally::account::HttpResponse* response, std::string*) {
-        if (request.url.ends_with("/auth/cli/refresh")) {
+        if (request.url.ends_with("/v1/auth/cli/refresh")) {
             asked_refresh = true;
         }
         response->status = 429;

--- a/tests/test_wally_opencode.cpp
+++ b/tests/test_wally_opencode.cpp
@@ -95,7 +95,7 @@ TestResult test_ephemeral_config_and_passthrough() {
     const wally::account::ConsoleClient console(
         [](const wally::account::HttpRequest& request, wally::account::HttpResponse* response,
            std::string*) {
-            if (!request.url.ends_with("/v1/me")) {
+            if (!request.url.ends_with("/v1/auth/me")) {
                 return false;
             }
             response->status = 200;
@@ -156,12 +156,12 @@ TestResult test_refreshes_expired_session_without_sdk_bootstrap() {
     bool refreshed = false;
     wally::account::ConsoleClient console([&](const wally::account::HttpRequest& request,
                                              wally::account::HttpResponse* response, std::string*) {
-        if (request.url.ends_with("/v1/me")) {
+        if (request.url.ends_with("/v1/auth/me")) {
             response->status = 200;
             response->body = Json{{"email", "developer@example.test"}}.dump();
             return true;
         }
-        if (!request.url.ends_with("/auth/cli/refresh") || request.bearer_token.size() != 0 ||
+        if (!request.url.ends_with("/v1/auth/cli/refresh") || request.bearer_token.size() != 0 ||
             Json::parse(request.body).at("refresh_token") != "refresh-token") {
             return false;
         }
@@ -215,7 +215,7 @@ TestResult test_restores_config_when_spawn_throws() {
         const wally::account::ConsoleClient console(
             [](const wally::account::HttpRequest& request, wally::account::HttpResponse* response,
                std::string*) {
-                if (!request.url.ends_with("/v1/me")) {
+                if (!request.url.ends_with("/v1/auth/me")) {
                     return false;
                 }
                 response->status = 200;


### PR DESCRIPTION
Part of the path relabel in InferenceInfra#484. Wally goes first, before the API stops serving the old paths.

Five paths move:

```
/auth/cli/start    ->  /v1/auth/cli/start
/auth/cli/poll     ->  /v1/auth/cli/poll
/auth/cli/refresh  ->  /v1/auth/cli/refresh
/auth/cli/revoke   ->  /v1/auth/cli/revoke
/v1/me             ->  /v1/auth/me
```

`/v1/cli/usage` is not one of them and is untouched.

Nothing breaks while this sits on main. The API still serves the old paths until InferenceInfra deploys last, so this change is inert until then and required after.

## The paths are declared once now

They were literals at each of the six call sites in `src/account/console.cpp`. Renaming five of them at once is exactly the job a literal in six places gets wrong, so they are constants at the top of the file and the call sites name them.

## AGENTS.md said not to do this

The sign-in section stated the four login endpoints are "not ours to rename". That was the standing rule and this PR breaks it on purpose, so the section now says what is actually true: renaming is expensive rather than forbidden, an installed binary 404s the moment the API drops the old path, and what makes it survivable this time is shipping the CLI release first while only three people hold the binary.

The same paragraph claimed the console side has a test that reads `src/account/console.cpp` and fails when the two drift. It does not. `api/tests/test_cli_auth.py` reads `api/tests/fixtures/rcli_console_contract.json`, a snapshot taken from a frozen commit, and checks it against InferenceInfra's own OpenAPI document. It never looks at this repo. Corrected, because the wrong version of that sentence is what makes someone think the two renames have to land together.

## Tests

`tests/test_account_cli.py` runs a real local HTTP server and matches paths exactly, so its handler, its expected request list, and its body lookups all move.

The C++ fixtures dispatch on `request.url.ends_with(...)`, and half of them could not have caught this. `/v1/auth/cli/start` still ends with `/auth/cli/start`, so those guards passed whether or not the source had been renamed. They now carry the full new path, which the old path does not match.

Break test, both halves:

```
# kIdentityPath back to /v1/me
wally_account_tests, wally_opencode_tests, wally_codex_tests,
wally_harness_tests, wally_account_cli_e2e  -- Failed

# kAuthStartPath back to /auth/cli/start
wally_account_tests, wally_account_cli_e2e  -- Failed

# restored
100% tests passed out of 10
```

The second one is the point. That guard used to pass with the old path in place.

`test_wally_contract` passes untouched: the generated binding carries schemas and a digest, not paths, so nothing regenerates.

## Left alone

`contracts/wally-cli-v1.openapi.json` still lists the old paths. It is a vendored copy of InferenceInfra's contract, re-cut by `contracts/extract-cli-contract.py` from upstream, and upstream renames last. It gets re-vendored after that, not hand-edited here.

`/api/v1/auth/sdk/authenticate` and `/api/v1/devices/register` in `src/net/control_plane.h` are the SDK device handshake, a different surface, not in the map.

## For InferenceInfra

Your rename will red `test_the_contract_matches_the_pinned_shipped_cli_fixture` until `rcli_console_contract.json` is regenerated with the new paths. The fixture pins all five and looks each one up in `app.openapi()["paths"]`. It is not mentioned in the plan file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated console authentication and identity requests to use versioned `/v1/auth/...` API paths.
  * Standardized all console control-plane endpoint references across account operations.

* **Documentation**
  * Clarified the supported versioned endpoints and historical endpoint migration details.

* **Tests**
  * Updated console request mocks and expectations to validate the versioned API routes.
  * Added contract validation against the console’s OpenAPI specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->