### PR TITLE
Preserve overload status and Retry-After before Anthropic streaming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(WALLY_SOURCES
     src/device_info.cpp
     src/net/control_plane.cpp
     src/net/loopback_auth.cpp
+    src/net/upstream_pool.cpp
     src/io/wav_io.cpp
     src/io/image_io.cpp
     src/io/output.cpp

--- a/docs/EDITORS.md
+++ b/docs/EDITORS.md
@@ -41,6 +41,16 @@ which is what lets an agent on the far side run the tools it was given rather
 than describe them. The JetBrains IDEs need no translator, because AI Assistant
 speaks OpenAI already.
 
+Both the translator and the JetBrains proxy keep their connections to the
+model endpoint open between requests, one per stream in flight, so a turn does
+not start with a new TLS handshake — against the hosted endpoint that handshake
+was measured at about half a second, and an agent makes several requests per
+turn. A connection that sat idle long enough for the far side to drop it (a
+long build, a walk away from the desk) is tried once more on a fresh one, only
+when nothing had come back yet; a request that has started answering is never
+repeated. So the first request after a long pause pays one handshake, and the
+rest of the session does not.
+
 ## Hosted models
 
 A model you have not downloaded can still answer, if the console serves it:

--- a/src/anthropic/messages.cpp
+++ b/src/anthropic/messages.cpp
@@ -1,17 +1,18 @@
 #include "anthropic/messages.h"
 
+#include <httplib.h>
+
 #include <algorithm>
 #include <atomic>
+#include <condition_variable>
 #include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <system_error>
 #include <thread>
-
-#include <httplib.h>
-#include <nlohmann/json.hpp>
 
 #include "anthropic/translate.h"
 #include "config/cli_paths.h"
@@ -58,8 +59,8 @@ void LogUpstreamError(const std::string& model, bool streaming, int status,
             character = ' ';
         }
     }
-    log << when << " model=" << model << " stream=" << (streaming ? 1 : 0)
-        << " status=" << status << " body=" << snippet << '\n';
+    log << when << " model=" << model << " stream=" << (streaming ? 1 : 0) << " status=" << status
+        << " body=" << snippet << '\n';
 }
 
 /// Split "http://host:port/v1" into the host root and the path prefix httplib
@@ -121,8 +122,11 @@ std::unique_ptr<Runtime> g_runtime;
 /// the first went out on a stale keep-alive (see RetryOnFreshConnection).
 /// `received_any` reports whether any response bytes reached `receiver`, which
 /// is what forbids the retry once output has started.
-httplib::Result PostUpstream(Runtime& runtime, const std::string& path, const std::string& body,
-                             const httplib::ContentReceiver& receiver, bool* received_any) {
+httplib::Result
+PostUpstream(Runtime& runtime, const std::string& path, const std::string& body,
+             const httplib::ContentReceiver& receiver, bool* received_any,
+             const httplib::ResponseHandler& headers = nullptr,
+             const std::function<void(httplib::Client*)>& client_changed = nullptr) {
     for (int attempt = 0; attempt < 2; ++attempt) {
         wally::net::UpstreamLease lease = runtime.pool->acquire(runtime.api_key);
         if (runtime.verbose) {
@@ -130,13 +134,34 @@ httplib::Result PostUpstream(Runtime& runtime, const std::string& path, const st
                              (lease.reused() ? "reused" : "fresh"));
         }
         *received_any = false;
-        httplib::Result reply =
-            receiver ? lease.client().Post(path, httplib::Headers(), body, "application/json",
-                                           [&](const char* data, size_t length) {
-                                               *received_any = true;
-                                               return receiver(data, length);
-                                           })
-                     : lease.client().Post(path, body, "application/json");
+        // Clear the published pointer before the lease dies, including when
+        // the HTTP library throws, so cancellation never sees a freed client.
+        struct Registration {
+            const std::function<void(httplib::Client*)>& changed;
+            ~Registration() {
+                if (changed)
+                    changed(nullptr);
+            }
+        } registration{client_changed};
+        if (client_changed)
+            client_changed(&lease.client());
+        bool received_headers = false;
+        httplib::Request outbound;
+        outbound.method = "POST";
+        outbound.path = path;
+        outbound.body = body;
+        outbound.set_header("Content-Type", "application/json");
+        outbound.response_handler = [&](const httplib::Response& response) {
+            received_headers = true;
+            return !headers || headers(response);
+        };
+        if (receiver) {
+            outbound.content_receiver = [&](const char* data, size_t length, uint64_t, uint64_t) {
+                *received_any = true;
+                return receiver(data, length);
+            };
+        }
+        httplib::Result reply = lease.client().send(outbound);
         if (reply) {
             // A complete reply, whatever its status, leaves the connection
             // clean; the lease goes back to the pool when it is destroyed.
@@ -144,11 +169,12 @@ httplib::Result PostUpstream(Runtime& runtime, const std::string& path, const st
         }
         // No reply: the socket is in no state to reuse.
         lease.discard();
-        if (attempt == 0 && wally::net::RetryOnFreshConnection(reply.error(), false,
-                                                                *received_any, lease.reused())) {
+        if (attempt == 0 && wally::net::RetryOnFreshConnection(reply.error(), received_headers,
+                                                               *received_any, lease.reused())) {
             if (runtime.verbose) {
-                out::status_line("anthropic: upstream connection was stale; retrying once on a "
-                                 "fresh one");
+                out::status_line(
+                    "anthropic: upstream connection was stale; retrying once on a "
+                    "fresh one");
             }
             continue;
         }
@@ -161,7 +187,7 @@ void HandleNonStreaming(Runtime& runtime, const Json& request, httplib::Response
     const Json upstream = translate::RequestToOpenAI(request, runtime.model);
     bool received_any = false;
     const httplib::Result reply = PostUpstream(runtime, runtime.prefix + "/chat/completions",
-                                              upstream.dump(), nullptr, &received_any);
+                                               upstream.dump(), nullptr, &received_any);
     if (!reply || reply->status < 200 || reply->status >= 300) {
         const int status = reply ? reply->status : 0;
         const std::string body = reply ? reply->body : std::string();
@@ -169,7 +195,7 @@ void HandleNonStreaming(Runtime& runtime, const Json& request, httplib::Response
         response.status = reply ? reply->status : 502;
         // A 429 from the hosted API carries a Retry-After the wrapped tool
         // should honor; httplib drops upstream headers unless we copy them.
-        if (reply && reply->status == 429 && reply->has_header("Retry-After")) {
+        if (reply && reply->has_header("Retry-After")) {
             response.set_header("Retry-After", reply->get_header_value("Retry-After"));
         }
         std::string type;
@@ -204,81 +230,182 @@ void HandleNonStreaming(Runtime& runtime, const Json& request, httplib::Response
                          "application/json");
 }
 
+// Read headers before the server commits its downstream response. A single
+// chunk slot bounds read-ahead and preserves backpressure on long streams.
+struct StreamingReply {
+    std::mutex mutex;
+    std::condition_variable changed;
+    std::thread worker;
+    httplib::Client* client = nullptr;
+    bool headers_ready = false;
+    bool finished = false;
+    bool stopped = false;
+    bool successful = false;
+    int status = 0;
+    std::string retry_after;
+    std::string chunk;
+    std::string error_body;
+
+    ~StreamingReply() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            stopped = true;
+            if (client)
+                client->stop();
+            changed.notify_all();
+        }
+        if (worker.joinable())
+            worker.join();
+    }
+
+    bool Read(std::string* next) {
+        std::unique_lock<std::mutex> lock(mutex);
+        changed.wait(lock, [&] { return !chunk.empty() || finished; });
+        if (chunk.empty())
+            return false;
+        *next = std::move(chunk);
+        chunk.clear();
+        changed.notify_all();
+        return true;
+    }
+};
+
 void HandleStreaming(Runtime& runtime, const Json& request, httplib::Response& response) {
     // The upstream body is built here rather than in the sink: the sink runs
     // after this function returns, and everything it touches has to outlive it.
-    auto upstream = std::make_shared<std::string>(
-        translate::RequestToOpenAI(request, runtime.model).dump());
+    auto upstream =
+        std::make_shared<std::string>(translate::RequestToOpenAI(request, runtime.model).dump());
     auto path = std::make_shared<std::string>(runtime.prefix + "/chat/completions");
     auto model = std::make_shared<std::string>(runtime.model);
     // The Runtime outlives every sink: Stop() stops the server and joins its
     // thread before the Runtime is destroyed, and the pool is shared besides.
     Runtime* owner = &runtime;
 
+    auto stream = std::make_shared<StreamingReply>();
+    StreamingReply* transfer = stream.get();
+    transfer->worker = std::thread([transfer, owner, upstream, path] {
+        bool received_any = false;
+        try {
+            auto reply = PostUpstream(
+                *owner, *path, *upstream,
+                [&](const char* data, size_t length) {
+                    std::unique_lock<std::mutex> lock(transfer->mutex);
+                    if (transfer->status < 200 || transfer->status >= 300) {
+                        constexpr size_t cap = 8192;
+                        transfer->error_body.append(
+                            data, std::min(length, cap - transfer->error_body.size()));
+                        return !transfer->stopped;
+                    }
+                    transfer->changed.wait(
+                        lock, [&] { return transfer->chunk.empty() || transfer->stopped; });
+                    if (transfer->stopped)
+                        return false;
+                    transfer->chunk.assign(data, length);
+                    transfer->changed.notify_all();
+                    return true;
+                },
+                &received_any,
+                [&](const httplib::Response& headers) {
+                    std::lock_guard<std::mutex> lock(transfer->mutex);
+                    transfer->status = headers.status;
+                    transfer->retry_after = headers.get_header_value("Retry-After");
+                    transfer->headers_ready = true;
+                    transfer->changed.notify_all();
+                    return !transfer->stopped;
+                },
+                [&](httplib::Client* client) {
+                    std::lock_guard<std::mutex> lock(transfer->mutex);
+                    transfer->client = client;
+                    if (client && transfer->stopped)
+                        client->stop();
+                });
+            std::lock_guard<std::mutex> lock(transfer->mutex);
+            transfer->successful = reply && reply->status >= 200 && reply->status < 300;
+            transfer->finished = true;
+            transfer->changed.notify_all();
+        } catch (const std::exception&) {
+            std::lock_guard<std::mutex> lock(transfer->mutex);
+            transfer->finished = true;
+            transfer->changed.notify_all();
+        }
+    });
+    {
+        std::unique_lock<std::mutex> lock(stream->mutex);
+        stream->changed.wait(lock, [&] { return stream->headers_ready || stream->finished; });
+        if (stream->status < 200 || stream->status >= 300) {
+            stream->changed.wait(lock, [&] { return stream->finished; });
+            response.status = stream->status ? stream->status : 502;
+            if (!stream->retry_after.empty())
+                response.set_header("Retry-After", stream->retry_after);
+            std::string type, message;
+            translate::UpstreamFailure(stream->status, stream->error_body, &type, &message);
+            LogUpstreamError(*model, true, stream->status, stream->error_body);
+            response.set_content(translate::ErrorBody(type, message), "application/json");
+            return;
+        }
+    }
+
     response.set_chunked_content_provider(
-        "text/event-stream",
-        [upstream, path, model, owner](size_t /*offset*/, httplib::DataSink& sink) {
+        "text/event-stream", [stream, model](size_t /*offset*/, httplib::DataSink& sink) {
             translate::StreamState state;
             state.model = *model;
             std::string pending;
-            // The upstream status is only known once Post returns, so the start
-            // of the body is kept regardless. On a non-2xx reply that is the
-            // error body, which would otherwise be fed to the SSE frame parser
-            // and silently dropped; capped so a real (2xx) stream of any size
-            // costs only these few KB.
+            // Retain a bounded prefix for diagnosing a transport failure
+            // after successful response headers have already been forwarded.
             std::string error_body;
             constexpr size_t kErrorBodyCap = 8192;
 
-            bool received_any = false;
-            const httplib::Result reply = PostUpstream(
-                *owner, *path, *upstream,
-                [&](const char* data, size_t length) {
-                    if (error_body.size() < kErrorBodyCap) {
-                        error_body.append(data,
-                                          std::min(length, kErrorBodyCap - error_body.size()));
+            auto receive = [&](const char* data, size_t length) {
+                if (error_body.size() < kErrorBodyCap) {
+                    error_body.append(data, std::min(length, kErrorBodyCap - error_body.size()));
+                }
+                pending.append(data, length);
+                // SSE frames are separated by a blank line, and a chunk can
+                // split one in half, so only whole frames are consumed.
+                size_t split = 0;
+                while ((split = pending.find("\n\n")) != std::string::npos) {
+                    const std::string frame = pending.substr(0, split);
+                    pending.erase(0, split + 2);
+                    const size_t field = frame.find("data:");
+                    if (field == std::string::npos) {
+                        continue;
                     }
-                    pending.append(data, length);
-                    // SSE frames are separated by a blank line, and a chunk can
-                    // split one in half, so only whole frames are consumed.
-                    size_t split = 0;
-                    while ((split = pending.find("\n\n")) != std::string::npos) {
-                        const std::string frame = pending.substr(0, split);
-                        pending.erase(0, split + 2);
-                        const size_t field = frame.find("data:");
-                        if (field == std::string::npos) {
-                            continue;
-                        }
-                        std::string payload = frame.substr(field + 5);
-                        while (!payload.empty() && (payload.front() == ' ' || payload.front() == '\r')) {
-                            payload.erase(payload.begin());
-                        }
-                        if (payload == "[DONE]") {
-                            continue;
-                        }
-                        Json chunk;
-                        try {
-                            chunk = Json::parse(payload);
-                        } catch (const Json::exception&) {
-                            continue;
-                        }
-                        std::string events;
-                        try {
-                            events = translate::StreamChunkToAnthropic(chunk, &state);
-                        } catch (const std::exception&) {
-                            // A chunk in a shape the mapping did not expect is
-                            // a chunk to skip, not a reason to kill the run.
-                            continue;
-                        }
-                        if (!events.empty() && !sink.write(events.data(), events.size())) {
-                            return false;
-                        }
+                    std::string payload = frame.substr(field + 5);
+                    while (!payload.empty() &&
+                           (payload.front() == ' ' || payload.front() == '\r')) {
+                        payload.erase(payload.begin());
                     }
-                    return true;
-                },
-                &received_any);
+                    if (payload == "[DONE]") {
+                        continue;
+                    }
+                    Json chunk;
+                    try {
+                        chunk = Json::parse(payload);
+                    } catch (const Json::exception&) {
+                        continue;
+                    }
+                    std::string events;
+                    try {
+                        events = translate::StreamChunkToAnthropic(chunk, &state);
+                    } catch (const std::exception&) {
+                        // A chunk in a shape the mapping did not expect is
+                        // a chunk to skip, not a reason to kill the run.
+                        continue;
+                    }
+                    if (!events.empty() && !sink.write(events.data(), events.size())) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+            std::string bytes;
+            while (stream->Read(&bytes)) {
+                if (!receive(bytes.data(), bytes.size()))
+                    return false;
+            }
 
-            if (!reply || reply->status < 200 || reply->status >= 300) {
-                const int status = reply ? reply->status : 0;
+            if (!stream->successful) {
+                const int status = 0;
                 LogUpstreamError(*model, true, status, error_body);
                 std::string type;
                 std::string message;
@@ -305,8 +432,8 @@ void HandleStreaming(Runtime& runtime, const Json& request, httplib::Response& r
 
 }  // namespace
 
-bool Start(const harness::Endpoint& upstream, const std::string& model, Shim* shim,
-           bool verbose, const std::string& advertised) {
+bool Start(const harness::Endpoint& upstream, const std::string& model, Shim* shim, bool verbose,
+           const std::string& advertised) {
     if (shim == nullptr) {
         return false;
     }
@@ -327,46 +454,46 @@ bool Start(const harness::Endpoint& upstream, const std::string& model, Shim* sh
     runtime->pool = std::make_shared<wally::net::UpstreamPool>(pool_options);
 
     Runtime* raw = runtime.get();
-    raw->server.Post("/v1/messages", [raw](const httplib::Request& request,
-                                           httplib::Response& response) {
-        if (!wally::net::ConstantTimeEquals(PresentedToken(request), raw->local_token)) {
-            response.status = 401;
-            response.set_content(
-                translate::ErrorBody("authentication_error",
-                                     "this local endpoint only serves the tool wally launched"),
-                "application/json");
-            return;
-        }
-        if (raw->verbose) {
-            out::status_line("anthropic: POST /v1/messages, " +
-                        std::to_string(request.body.size()) + " bytes");
-        }
-        Json parsed;
-        try {
-            parsed = Json::parse(request.body);
-        } catch (const Json::exception& error) {
-            response.status = 400;
-            response.set_content(translate::ErrorBody("invalid_request_error", error.what()),
-                                 "application/json");
-            return;
-        }
-        try {
-            if (parsed.value("stream", false)) {
-                HandleStreaming(*raw, parsed, response);
-            } else {
-                HandleNonStreaming(*raw, parsed, response);
+    raw->server.Post(
+        "/v1/messages", [raw](const httplib::Request& request, httplib::Response& response) {
+            if (!wally::net::ConstantTimeEquals(PresentedToken(request), raw->local_token)) {
+                response.status = 401;
+                response.set_content(
+                    translate::ErrorBody("authentication_error",
+                                         "this local endpoint only serves the tool wally launched"),
+                    "application/json");
+                return;
             }
-        } catch (const std::exception& error) {
-            // httplib does not catch, and an exception leaving here reaches
-            // std::terminate: the editor's model call would abort wally.
             if (raw->verbose) {
-                out::status_line(std::string("anthropic: request failed: ") + error.what());
+                out::status_line("anthropic: POST /v1/messages, " +
+                                 std::to_string(request.body.size()) + " bytes");
             }
-            response.status = 500;
-            response.set_content(translate::ErrorBody("api_error", error.what()),
-                                 "application/json");
-        }
-    });
+            Json parsed;
+            try {
+                parsed = Json::parse(request.body);
+            } catch (const Json::exception& error) {
+                response.status = 400;
+                response.set_content(translate::ErrorBody("invalid_request_error", error.what()),
+                                     "application/json");
+                return;
+            }
+            try {
+                if (parsed.value("stream", false)) {
+                    HandleStreaming(*raw, parsed, response);
+                } else {
+                    HandleNonStreaming(*raw, parsed, response);
+                }
+            } catch (const std::exception& error) {
+                // httplib does not catch, and an exception leaving here reaches
+                // std::terminate: the editor's model call would abort wally.
+                if (raw->verbose) {
+                    out::status_line(std::string("anthropic: request failed: ") + error.what());
+                }
+                response.status = 500;
+                response.set_content(translate::ErrorBody("api_error", error.what()),
+                                     "application/json");
+            }
+        });
 
     // Discovery, in Anthropic's shape rather than OpenAI's.
     //
@@ -377,16 +504,15 @@ bool Start(const harness::Endpoint& upstream, const std::string& model, Shim* sh
     raw->server.Get("/v1/models", [raw](const httplib::Request&, httplib::Response& response) {
         if (raw->verbose) {
             out::status_line("anthropic: GET /v1/models -> " + raw->advertised + " (serving " +
-                        raw->model + ")");
+                             raw->model + ")");
         }
         // The shape claude.com/docs/third-party/claude-desktop documents for a
         // gateway, which is OpenAI's list envelope rather than Anthropic's.
         // Guessing the Anthropic shape here is what produced "Gateway returned
         // no usable models".
         const Json entry{{"id", raw->advertised}, {"object", "model"}};
-        response.set_content(
-            Json{{"object", "list"}, {"data", Json::array({entry})}}.dump(),
-            "application/json");
+        response.set_content(Json{{"object", "list"}, {"data", Json::array({entry})}}.dump(),
+                             "application/json");
     });
 
     // Claude Code probes this before it sends anything and treats a failure as
@@ -408,20 +534,19 @@ bool Start(const harness::Endpoint& upstream, const std::string& model, Shim* sh
 
     // A route we do not translate should say so, not 404 into a silence the
     // reader has to guess at.
-    raw->server.set_error_handler([raw](const httplib::Request& request,
-                                        httplib::Response& response) {
-        if (raw->verbose) {
-            out::status_line("anthropic: " + request.method + " " + request.path + " -> " +
-                        std::to_string(response.status));
-        }
-        if (response.body.empty()) {
-            response.set_content(
-                translate::ErrorBody("not_found_error",
-                                     request.method + " " + request.path +
-                                         " is not something wally translates"),
-                "application/json");
-        }
-    });
+    raw->server.set_error_handler(
+        [raw](const httplib::Request& request, httplib::Response& response) {
+            if (raw->verbose) {
+                out::status_line("anthropic: " + request.method + " " + request.path + " -> " +
+                                 std::to_string(response.status));
+            }
+            if (response.body.empty()) {
+                response.set_content(translate::ErrorBody("not_found_error",
+                                                          request.method + " " + request.path +
+                                                              " is not something wally translates"),
+                                     "application/json");
+            }
+        });
 
     const int port = raw->server.bind_to_any_port("127.0.0.1");
     if (port <= 0) {

--- a/src/anthropic/messages.cpp
+++ b/src/anthropic/messages.cpp
@@ -17,6 +17,7 @@
 #include "config/cli_paths.h"
 #include "io/output.h"
 #include "net/loopback_auth.h"
+#include "net/upstream_pool.h"
 
 namespace wally::anthropic {
 namespace {
@@ -93,6 +94,10 @@ struct Runtime {
     // processes out.
     std::string local_token;
     bool verbose = false;
+    // Upstream connections, kept open across requests. Shared, not owned:
+    // a streaming sink can still be running its request after Stop(), and
+    // the lease it holds keeps the pool alive until it is done.
+    std::shared_ptr<wally::net::UpstreamPool> pool;
 };
 
 // The token the wrapped tool presents, read from either header Claude Code may
@@ -112,20 +117,51 @@ std::string PresentedToken(const httplib::Request& request) {
 
 std::unique_ptr<Runtime> g_runtime;
 
-void ApplyAuth(httplib::Client& client, const std::string& api_key) {
-    if (!api_key.empty()) {
-        client.set_bearer_token_auth(api_key);
+/// Sends `body` upstream on a pooled connection, once more on a fresh one if
+/// the first went out on a stale keep-alive (see RetryOnFreshConnection).
+/// `received_any` reports whether any response bytes reached `receiver`, which
+/// is what forbids the retry once output has started.
+httplib::Result PostUpstream(Runtime& runtime, const std::string& path, const std::string& body,
+                             const httplib::ContentReceiver& receiver, bool* received_any) {
+    for (int attempt = 0; attempt < 2; ++attempt) {
+        wally::net::UpstreamLease lease = runtime.pool->acquire(runtime.api_key);
+        if (runtime.verbose) {
+            out::status_line(std::string("anthropic: upstream connection ") +
+                             (lease.reused() ? "reused" : "fresh"));
+        }
+        *received_any = false;
+        httplib::Result reply =
+            receiver ? lease.client().Post(path, httplib::Headers(), body, "application/json",
+                                           [&](const char* data, size_t length) {
+                                               *received_any = true;
+                                               return receiver(data, length);
+                                           })
+                     : lease.client().Post(path, body, "application/json");
+        if (reply) {
+            // A complete reply, whatever its status, leaves the connection
+            // clean; the lease goes back to the pool when it is destroyed.
+            return reply;
+        }
+        // No reply: the socket is in no state to reuse.
+        lease.discard();
+        if (attempt == 0 && wally::net::RetryOnFreshConnection(reply.error(), false,
+                                                                *received_any, lease.reused())) {
+            if (runtime.verbose) {
+                out::status_line("anthropic: upstream connection was stale; retrying once on a "
+                                 "fresh one");
+            }
+            continue;
+        }
+        return reply;
     }
+    return httplib::Result{nullptr, httplib::Error::Unknown};
 }
 
 void HandleNonStreaming(Runtime& runtime, const Json& request, httplib::Response& response) {
-    httplib::Client client(runtime.origin);
-    client.set_read_timeout(600, 0);
-    ApplyAuth(client, runtime.api_key);
-
     const Json upstream = translate::RequestToOpenAI(request, runtime.model);
-    const httplib::Result reply =
-        client.Post(runtime.prefix + "/chat/completions", upstream.dump(), "application/json");
+    bool received_any = false;
+    const httplib::Result reply = PostUpstream(runtime, runtime.prefix + "/chat/completions",
+                                              upstream.dump(), nullptr, &received_any);
     if (!reply || reply->status < 200 || reply->status >= 300) {
         const int status = reply ? reply->status : 0;
         const std::string body = reply ? reply->body : std::string();
@@ -173,18 +209,15 @@ void HandleStreaming(Runtime& runtime, const Json& request, httplib::Response& r
     // after this function returns, and everything it touches has to outlive it.
     auto upstream = std::make_shared<std::string>(
         translate::RequestToOpenAI(request, runtime.model).dump());
-    auto origin = std::make_shared<std::string>(runtime.origin);
     auto path = std::make_shared<std::string>(runtime.prefix + "/chat/completions");
-    auto api_key = std::make_shared<std::string>(runtime.api_key);
     auto model = std::make_shared<std::string>(runtime.model);
+    // The Runtime outlives every sink: Stop() stops the server and joins its
+    // thread before the Runtime is destroyed, and the pool is shared besides.
+    Runtime* owner = &runtime;
 
     response.set_chunked_content_provider(
         "text/event-stream",
-        [upstream, origin, path, api_key, model](size_t /*offset*/, httplib::DataSink& sink) {
-            httplib::Client client(*origin);
-            client.set_read_timeout(600, 0);
-            ApplyAuth(client, *api_key);
-
+        [upstream, path, model, owner](size_t /*offset*/, httplib::DataSink& sink) {
             translate::StreamState state;
             state.model = *model;
             std::string pending;
@@ -196,8 +229,9 @@ void HandleStreaming(Runtime& runtime, const Json& request, httplib::Response& r
             std::string error_body;
             constexpr size_t kErrorBodyCap = 8192;
 
-            const httplib::Result reply = client.Post(
-                *path, httplib::Headers(), *upstream, "application/json",
+            bool received_any = false;
+            const httplib::Result reply = PostUpstream(
+                *owner, *path, *upstream,
                 [&](const char* data, size_t length) {
                     if (error_body.size() < kErrorBodyCap) {
                         error_body.append(data,
@@ -240,7 +274,8 @@ void HandleStreaming(Runtime& runtime, const Json& request, httplib::Response& r
                         }
                     }
                     return true;
-                });
+                },
+                &received_any);
 
             if (!reply || reply->status < 200 || reply->status >= 300) {
                 const int status = reply ? reply->status : 0;
@@ -287,6 +322,9 @@ bool Start(const harness::Endpoint& upstream, const std::string& model, Shim* sh
     runtime->advertised = advertised.empty() ? model : advertised;
     runtime->local_token = wally::net::GenerateLoopbackToken();
     runtime->verbose = verbose;
+    wally::net::UpstreamOptions pool_options;
+    pool_options.origin = runtime->origin;
+    runtime->pool = std::make_shared<wally::net::UpstreamPool>(pool_options);
 
     Runtime* raw = runtime.get();
     raw->server.Post("/v1/messages", [raw](const httplib::Request& request,

--- a/src/ide/openai_proxy.cpp
+++ b/src/ide/openai_proxy.cpp
@@ -19,6 +19,7 @@
 #include "account/credentials.h"
 #include "io/output.h"
 #include "net/loopback_auth.h"
+#include "net/upstream_pool.h"
 
 namespace wally::ide {
 namespace {
@@ -51,6 +52,9 @@ struct Runtime {
     // out; this keeps another local process out.
     std::string local_token;
     bool verbose = false;
+    // Upstream connections kept open across requests (wally #80). Shared: a
+    // streaming sink still running after StopProxy() holds a lease on it.
+    std::shared_ptr<wally::net::UpstreamPool> pool;
 };
 
 std::unique_ptr<Runtime> g_runtime;
@@ -101,15 +105,6 @@ bool RenewToken(Runtime& runtime) {
     runtime.api_key = grant.access_token;
     Trace(runtime.verbose, "REFRESHED");
     return true;
-}
-
-httplib::Client Upstream(const Runtime& runtime) {
-    httplib::Client client(runtime.origin);
-    client.set_read_timeout(600, 0);
-    if (!runtime.api_key.empty()) {
-        client.set_bearer_token_auth(runtime.api_key);
-    }
-    return client;
 }
 
 /// Where the proxy writes its trace, when one was asked for.
@@ -273,9 +268,31 @@ void Fail(httplib::Response& response, int status, const std::string& message) {
 ///
 /// Nothing is parsed. Both ends speak the same wire format, so reframing SSE
 /// here would only add a place for it to go wrong — and did, the first time.
+/// A non-streaming request on a pooled connection, once more on a fresh one
+/// if a reused connection turned out to be stale. Nothing has been answered
+/// to the editor when that decision is made.
+httplib::Result PostOnce(Runtime& runtime, const std::string& path, const std::string& body) {
+    for (int attempt = 0; attempt < 2; ++attempt) {
+        wally::net::UpstreamLease lease = runtime.pool->acquire(runtime.api_key);
+        Trace(runtime.verbose,
+              lease.reused() ? "UPSTREAM reused connection" : "UPSTREAM fresh connection");
+        httplib::Result reply = lease.client().Post(path, body, "application/json");
+        if (reply) {
+            return reply;
+        }
+        lease.discard();
+        if (attempt == 0 &&
+            wally::net::RetryOnFreshConnection(reply.error(), false, false, lease.reused())) {
+            Trace(runtime.verbose, "UPSTREAM stale connection; retrying once on a fresh one");
+            continue;
+        }
+        return reply;
+    }
+    return httplib::Result{nullptr, httplib::Error::Unknown};
+}
+
 void Stream(Runtime& runtime, const std::string& body, httplib::Response& response) {
     auto request = std::make_shared<std::string>(body);
-    auto origin = std::make_shared<std::string>(runtime.origin);
     auto path = std::make_shared<std::string>(runtime.prefix + "/chat/completions");
     auto api_key = std::make_shared<std::string>(runtime.api_key);
 
@@ -286,17 +303,21 @@ void Stream(Runtime& runtime, const std::string& body, httplib::Response& respon
 
     response.set_chunked_content_provider(
         "text/event-stream",
-        [request, origin, path, api_key, verbose, owner](size_t, httplib::DataSink& sink) {
-          // Two attempts at most: the second only after a token the console
-          // has just renewed. Nothing reaches the sink until an event stream
-          // is recognised, so a retry cannot duplicate output.
-          for (int attempt = 0; attempt < 2; ++attempt) {
-            httplib::Client client(*origin);
-            client.set_read_timeout(600, 0);
-            const std::string token = attempt == 0 ? *api_key : owner->api_key;
-            if (!token.empty()) {
-                client.set_bearer_token_auth(token);
-            }
+        [request, path, api_key, verbose, owner](size_t, httplib::DataSink& sink) {
+          // Two kinds of second attempt, each at most once: after a token
+          // the console has just renewed (a 401 came back), and on a fresh
+          // connection when a REUSED one turned out to be stale (nothing
+          // came back at all -- RetryOnFreshConnection). Nothing reaches the
+          // sink until an event stream is recognised, so neither retry can
+          // duplicate output.
+          int auth_attempt = 0;
+          bool stale_retried = false;
+          for (;;) {
+            const std::string token = auth_attempt == 0 ? *api_key : owner->api_key;
+            wally::net::UpstreamLease lease = owner->pool->acquire(token);
+            Trace(*verbose, lease.reused() ? "UPSTREAM reused connection"
+                                           : "UPSTREAM fresh connection");
+            bool received_any = false;
 
             // An upstream that refuses the request answers with a JSON error and
             // no SSE framing at all. Forwarding those bytes as if they were
@@ -329,8 +350,9 @@ void Stream(Runtime& runtime, const std::string& body, httplib::Response& respon
                 return true;
             };
             const httplib::Result reply =
-                client.Post(*path, httplib::Headers(), *request, "application/json",
+                lease.client().Post(*path, httplib::Headers(), *request, "application/json",
                             [&](const char* data, size_t length) {
+                                received_any = true;
                                 if (decided) {
                                     if (!streaming) {
                                         head.append(data, length);
@@ -362,7 +384,18 @@ void Stream(Runtime& runtime, const std::string& body, httplib::Response& respon
                 return true;
             }
 
-            if (attempt == 0 && reply && LooksLikeAuthFailure(head) && RenewToken(*owner)) {
+            if (!reply) {
+                // The socket is in no state to reuse.
+                lease.discard();
+                if (!stale_retried &&
+                    wally::net::RetryOnFreshConnection(reply.error(), false, received_any,
+                                                       lease.reused())) {
+                    stale_retried = true;
+                    Trace(*verbose, "UPSTREAM stale connection; retrying once on a fresh one");
+                    continue;
+                }
+            } else if (auth_attempt == 0 && LooksLikeAuthFailure(head) && RenewToken(*owner)) {
+                ++auth_attempt;
                 head.clear();
                 pending.clear();
                 decided = false;
@@ -395,8 +428,6 @@ void Stream(Runtime& runtime, const std::string& body, httplib::Response& respon
             sink.done();
             return true;
           }
-          sink.done();
-          return true;
         });
 }
 
@@ -418,6 +449,9 @@ bool StartProxy(const harness::Endpoint& endpoint, const std::string& model, int
     runtime->model = model;
     runtime->local_token = wally::net::GenerateLoopbackToken();
     runtime->verbose = verbose;
+    wally::net::UpstreamOptions pool_options;
+    pool_options.origin = runtime->origin;
+    runtime->pool = std::make_shared<wally::net::UpstreamPool>(pool_options);
 
     Runtime* raw = runtime.get();
     // Every handler catches. An exception thrown into cpp-httplib takes the
@@ -464,9 +498,8 @@ bool StartProxy(const harness::Endpoint& endpoint, const std::string& model, int
                                  Stream(*raw, body, response);
                                  return;
                              }
-                             httplib::Client client = Upstream(*raw);
-                             const httplib::Result reply = client.Post(
-                                 raw->prefix + "/chat/completions", body, "application/json");
+                             const httplib::Result reply =
+                                 PostOnce(*raw, raw->prefix + "/chat/completions", body);
                              if (!reply) {
                                  Fail(response, 502, "the model endpoint did not answer");
                                  return;

--- a/src/net/upstream_pool.cpp
+++ b/src/net/upstream_pool.cpp
@@ -1,0 +1,99 @@
+#include "net/upstream_pool.h"
+
+#include <utility>
+
+namespace wally::net {
+
+UpstreamLease::UpstreamLease(std::shared_ptr<UpstreamPool> pool,
+                             std::unique_ptr<httplib::Client> client, bool reused)
+    : pool_(std::move(pool)), client_(std::move(client)), reused_(reused) {}
+
+UpstreamLease::UpstreamLease(UpstreamLease&& other) noexcept
+    : pool_(std::move(other.pool_)),
+      client_(std::move(other.client_)),
+      reused_(other.reused_),
+      discard_(other.discard_) {}
+
+UpstreamLease& UpstreamLease::operator=(UpstreamLease&& other) noexcept {
+    if (this != &other) {
+        pool_ = std::move(other.pool_);
+        client_ = std::move(other.client_);
+        reused_ = other.reused_;
+        discard_ = other.discard_;
+    }
+    return *this;
+}
+
+UpstreamLease::~UpstreamLease() {
+    if (pool_ && client_ && !discard_) {
+        pool_->give_back(std::move(client_));
+    }
+    // A discarded client is destroyed here, which closes its socket.
+}
+
+UpstreamPool::UpstreamPool(UpstreamOptions options) : options_(std::move(options)) {}
+
+std::unique_ptr<httplib::Client> UpstreamPool::build() const {
+    auto client = std::make_unique<httplib::Client>(options_.origin);
+    client->set_keep_alive(true);
+    client->set_read_timeout(options_.read_timeout_seconds, 0);
+    client->set_connection_timeout(options_.connect_timeout_seconds, 0);
+    return client;
+}
+
+UpstreamLease UpstreamPool::acquire(const std::string& bearer) {
+    std::unique_ptr<httplib::Client> client;
+    bool reused = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!idle_.empty()) {
+            // The most recently returned client: its connection is the one
+            // least likely to have been closed by an idle timeout.
+            client = std::move(idle_.back());
+            idle_.pop_back();
+            reused = true;
+        }
+    }
+    if (!client) {
+        client = build();
+    }
+    // Set on every lease, never baked in: the JetBrains proxy renews its
+    // token on a 401 and retries with the new one on the same pool.
+    client->set_bearer_token_auth(bearer);
+    return UpstreamLease(shared_from_this(), std::move(client), reused);
+}
+
+void UpstreamPool::give_back(std::unique_ptr<httplib::Client> client) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idle_.size() < options_.idle_limit) {
+        idle_.push_back(std::move(client));
+    }
+    // Past the limit the client is destroyed on return, closing its socket.
+}
+
+size_t UpstreamPool::idle() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return idle_.size();
+}
+
+bool RetryOnFreshConnection(httplib::Error error, bool has_response, bool received_any,
+                            bool reused) {
+    if (!reused || has_response || received_any) {
+        return false;
+    }
+    switch (error) {
+        case httplib::Error::Connection:
+        case httplib::Error::ConnectionClosed:
+        case httplib::Error::Read:
+        case httplib::Error::Write:
+        case httplib::Error::SSLConnection:
+            return true;
+        default:
+            // Timeouts are not stale connections: a read timeout after 600 s
+            // is a slow or hung upstream, and a connect timeout is the
+            // network, and neither should be paid twice.
+            return false;
+    }
+}
+
+}  // namespace wally::net

--- a/src/net/upstream_pool.cpp
+++ b/src/net/upstream_pool.cpp
@@ -16,6 +16,9 @@ UpstreamLease::UpstreamLease(UpstreamLease&& other) noexcept
 
 UpstreamLease& UpstreamLease::operator=(UpstreamLease&& other) noexcept {
     if (this != &other) {
+        // Whatever this lease held goes back (or is dropped) exactly as it
+        // would at end of scope, before the other lease's client moves in.
+        UpstreamLease previous(std::move(*this));
         pool_ = std::move(other.pool_);
         client_ = std::move(other.client_);
         reused_ = other.reused_;

--- a/src/net/upstream_pool.h
+++ b/src/net/upstream_pool.h
@@ -1,0 +1,121 @@
+#ifndef WALLY_NET_UPSTREAM_POOL_H
+#define WALLY_NET_UPSTREAM_POOL_H
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <httplib.h>
+
+/// Reusable connections to one upstream origin.
+///
+/// The translators that sit between an editor and a model endpoint used to
+/// build an `httplib::Client` per request, which opens a TCP connection and
+/// completes a TLS handshake every time — measured at ~541 ms against the
+/// hosted endpoint, paid before a byte of the request is sent, on every turn
+/// (wally #80). A pool keeps clients with keep-alive on and lends them out.
+///
+/// Why a pool and not one shared client: an `httplib::Client` serialises
+/// requests on its single socket, so one shared client would queue an
+/// editor's parallel calls behind a stream that lasts minutes. Each request
+/// in flight gets its own client; idle ones are kept for the next request.
+///
+/// A lease goes back to the pool only when its request completed cleanly. A
+/// stream the editor abandoned, or a transport error, leaves the socket in a
+/// state nothing should reuse, so those leases are discarded and the socket
+/// closed with them.
+namespace wally::net {
+
+struct UpstreamOptions {
+    /// "https://host" or "http://127.0.0.1:port" — scheme and authority only.
+    std::string origin;
+    /// How long a single read may block. Long prefills are not hangs.
+    int read_timeout_seconds = 600;
+    /// How long a TCP connect may take. httplib's default is 300 s, which
+    /// leaves an editor's request hanging for five minutes when a connect is
+    /// black-holed (a laptop changing networks, a VPN flipping); ten seconds
+    /// is twenty times the worst handshake measured against the endpoint.
+    int connect_timeout_seconds = 10;
+    /// Idle clients kept for reuse. Leases beyond this are still created; a
+    /// returned lease past the limit is closed instead of kept.
+    size_t idle_limit = 4;
+};
+
+class UpstreamPool;
+
+/// One client checked out of a pool. Movable, not copyable. Returned to the
+/// pool on destruction unless `discard()` was called.
+class UpstreamLease {
+   public:
+    UpstreamLease(UpstreamLease&& other) noexcept;
+    UpstreamLease& operator=(UpstreamLease&& other) noexcept;
+    UpstreamLease(const UpstreamLease&) = delete;
+    UpstreamLease& operator=(const UpstreamLease&) = delete;
+    ~UpstreamLease();
+
+    httplib::Client& client() { return *client_; }
+
+    /// True when this client came from the idle set and may be holding a
+    /// connection the far side has since closed. The retry rule reads this.
+    bool reused() const { return reused_; }
+
+    /// Do not return this client to the pool; its socket is closed with it.
+    void discard() { discard_ = true; }
+
+   private:
+    friend class UpstreamPool;
+    UpstreamLease(std::shared_ptr<UpstreamPool> pool, std::unique_ptr<httplib::Client> client,
+                  bool reused);
+
+    std::shared_ptr<UpstreamPool> pool_;
+    std::unique_ptr<httplib::Client> client_;
+    bool reused_ = false;
+    bool discard_ = false;
+};
+
+/// Must be owned by a `std::shared_ptr`: leases hold a reference so a pool
+/// outlives every request still using one of its clients, even after the
+/// translator that created it has stopped.
+class UpstreamPool : public std::enable_shared_from_this<UpstreamPool> {
+   public:
+    explicit UpstreamPool(UpstreamOptions options);
+
+    /// A client for one request, with `bearer` set as its Authorization
+    /// (none when empty). Reuses an idle client when there is one.
+    UpstreamLease acquire(const std::string& bearer);
+
+    /// Idle clients currently held. For tests and the verbose trace.
+    size_t idle() const;
+
+    const UpstreamOptions& options() const { return options_; }
+
+   private:
+    friend class UpstreamLease;
+    void give_back(std::unique_ptr<httplib::Client> client);
+    std::unique_ptr<httplib::Client> build() const;
+
+    UpstreamOptions options_;
+    mutable std::mutex mutex_;
+    std::vector<std::unique_ptr<httplib::Client>> idle_;
+};
+
+/// Whether a failed request should be tried once more on a fresh connection.
+///
+/// Only a request that went out on a REUSED connection, got no HTTP status
+/// back, delivered nothing to the caller, and failed with a connection-class
+/// error is retried. That is the stale keep-alive case — the far side closed
+/// an idle connection and the first write or read on it fails — and it is the
+/// same heuristic curl and browsers apply. A fresh connection that fails is a
+/// real outage and must surface; a request that has produced output must
+/// never be repeated.
+///
+/// Accepted risk, capped at one retry: "no bytes back" does not prove the
+/// server never processed the request, so a retry can in rare cases run a
+/// generation twice. Callers log the retry so such a case is traceable.
+bool RetryOnFreshConnection(httplib::Error error, bool has_response, bool received_any,
+                            bool reused);
+
+}  // namespace wally::net
+
+#endif  // WALLY_NET_UPSTREAM_POOL_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,15 @@ target_link_libraries(test_wally_codex PRIVATE wally_core nlohmann_json::nlohman
 wally_stage_windows_runtime_dlls(test_wally_codex)
 add_test(NAME wally_codex_tests COMMAND test_wally_codex --run-all)
 
+add_executable(test_wally_anthropic test_wally_anthropic.cpp)
+target_include_directories(test_wally_anthropic PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+# httplib is private to wally_core; this suite runs a fake upstream server of
+# its own, so it links the header directly.
+target_link_libraries(test_wally_anthropic PRIVATE wally_core httplib::httplib nlohmann_json::nlohmann_json)
+wally_stage_windows_runtime_dlls(test_wally_anthropic)
+add_test(NAME wally_anthropic_tests COMMAND test_wally_anthropic --run-all)
+set_tests_properties(wally_anthropic_tests PROPERTIES TIMEOUT 60)
+
 add_executable(test_wally_harness test_wally_harness.cpp)
 target_include_directories(test_wally_harness PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(test_wally_harness PRIVATE wally_core nlohmann_json::nlohmann_json)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,13 @@ wally_stage_windows_runtime_dlls(test_wally_anthropic)
 add_test(NAME wally_anthropic_tests COMMAND test_wally_anthropic --run-all)
 set_tests_properties(wally_anthropic_tests PROPERTIES TIMEOUT 60)
 
+add_executable(test_wally_ide_proxy test_wally_ide_proxy.cpp)
+target_include_directories(test_wally_ide_proxy PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(test_wally_ide_proxy PRIVATE wally_core httplib::httplib nlohmann_json::nlohmann_json)
+wally_stage_windows_runtime_dlls(test_wally_ide_proxy)
+add_test(NAME wally_ide_proxy_tests COMMAND test_wally_ide_proxy --run-all)
+set_tests_properties(wally_ide_proxy_tests PROPERTIES TIMEOUT 60)
+
 add_executable(test_wally_harness test_wally_harness.cpp)
 target_include_directories(test_wally_harness PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(test_wally_harness PRIVATE wally_core nlohmann_json::nlohmann_json)

--- a/tests/fake_upstream.h
+++ b/tests/fake_upstream.h
@@ -1,0 +1,272 @@
+#ifndef WALLY_TESTS_FAKE_UPSTREAM_H
+#define WALLY_TESTS_FAKE_UPSTREAM_H
+
+// Fake OpenAI-shaped upstreams for the loopback translators' tests. Every
+// assertion built on these is about which TCP connection a request arrived
+// on, read from the server's side as the peer's ephemeral port: the same port
+// across requests means the same connection was reused; a different port
+// means a new connect (and, against the real endpoint, a new TLS handshake).
+// No network beyond 127.0.0.1, no models.
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#if !defined(_WIN32)
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace wally_tests {
+
+using Json = nlohmann::json;
+
+
+constexpr const char* kStreamBody =
+    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
+    "\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n"
+    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
+    "\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"
+    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
+    "\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
+    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],"
+    "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}\n\n"
+    "data: [DONE]\n\n";
+
+constexpr const char* kJsonBody =
+    "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"choices\":[{\"index\":0,"
+    "\"message\":{\"role\":\"assistant\",\"content\":\"hello\"},\"finish_reason\":\"stop\"}],"
+    "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}";
+
+/// An OpenAI-shaped upstream that remembers which connection each request
+/// arrived on. `hold_streams_until` makes streaming responses wait until that
+/// many requests have arrived before emitting anything, so two concurrent
+/// requests are provably in flight together rather than one finishing and
+/// lending its connection to the next.
+class FakeUpstream {
+   public:
+    FakeUpstream() {
+        server_.Post("/v1/chat/completions",
+                     [this](const httplib::Request& request, httplib::Response& response) {
+                         Record(request);
+                         const bool streaming = Json::parse(request.body).value("stream", false);
+                         if (!streaming) {
+                             response.set_content(kJsonBody, "application/json");
+                             return;
+                         }
+                         response.set_chunked_content_provider(
+                             "text/event-stream",
+                             [this](size_t, httplib::DataSink& sink) {
+                                 WaitForHold();
+                                 const std::string body = kStreamBody;
+                                 if (die_) {
+                                     size_t cut = body.find("\n\n");
+                                     cut = body.find("\n\n", cut + 2) + 2;
+                                     sink.write(body.data(), cut);
+                                     return false;  // httplib closes the connection
+                                 }
+                                 sink.write(body.data(), body.size());
+                                 sink.done();
+                                 return true;
+                             });
+                     });
+        port_ = server_.bind_to_any_port("127.0.0.1");
+        thread_ = std::thread([this] { server_.listen_after_bind(); });
+        server_.wait_until_ready();
+    }
+
+    ~FakeUpstream() {
+        server_.stop();
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    std::string base_url() const { return "http://127.0.0.1:" + std::to_string(port_) + "/v1"; }
+
+    std::vector<int> ports() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return ports_;
+    }
+
+    void hold_streams_until(int arrivals) { hold_until_ = arrivals; }
+
+    /// Send the first two SSE frames, then drop the connection without
+    /// finishing the stream: an upstream that died mid-generation.
+    void die_mid_stream(bool on) { die_ = on; }
+
+   private:
+    void Record(const httplib::Request& request) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        ports_.push_back(request.remote_port);
+        ++arrivals_;
+        arrived_.notify_all();
+    }
+
+    void WaitForHold() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        arrived_.wait_for(lock, std::chrono::seconds(5),
+                          [this] { return arrivals_ >= hold_until_; });
+    }
+
+    httplib::Server server_;
+    std::thread thread_;
+    int port_ = 0;
+    mutable std::mutex mutex_;
+    std::condition_variable arrived_;
+    std::vector<int> ports_;
+    int arrivals_ = 0;
+    int hold_until_ = 0;
+    bool die_ = false;
+};
+
+#if !defined(_WIN32)
+/// An upstream that leaves a keep-alive connection HALF-OPEN: it answers the
+/// first request on each connection and keeps the socket, then on the second
+/// request of that connection reads it and closes without answering. That is
+/// the stale keep-alive shape a client cannot detect before sending -- the
+/// socket looks alive right up to the read that gets nothing back -- and the
+/// one case RetryOnFreshConnection exists for. A server that closes with FIN
+/// after answering would not do: httplib notices that before it sends.
+///
+/// Raw sockets because httplib's server has no way to drop a connection
+/// without answering. POSIX only; the retry rule itself is covered on every
+/// platform by the table test.
+class HalfOpenUpstream {
+   public:
+    HalfOpenUpstream() {
+        listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+        sockaddr_in address{};
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        address.sin_port = 0;
+        int one = 1;
+        ::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+        if (::bind(listen_fd_, reinterpret_cast<sockaddr*>(&address), sizeof(address)) != 0 ||
+            ::listen(listen_fd_, 8) != 0) {
+            return;
+        }
+        socklen_t length = sizeof(address);
+        ::getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&address), &length);
+        port_ = ntohs(address.sin_port);
+        acceptor_ = std::thread([this] { Accept(); });
+    }
+
+    ~HalfOpenUpstream() {
+        ::shutdown(listen_fd_, SHUT_RDWR);
+        ::close(listen_fd_);
+        if (acceptor_.joinable()) {
+            acceptor_.join();
+        }
+        for (std::thread& t : handlers_) {
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    }
+
+    bool ok() const { return port_ > 0; }
+    std::string base_url() const { return "http://127.0.0.1:" + std::to_string(port_) + "/v1"; }
+
+    /// Peer port of every request read, answered or not, in arrival order.
+    std::vector<int> ports() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return ports_;
+    }
+
+   private:
+    void Accept() {
+        for (;;) {
+            sockaddr_in peer{};
+            socklen_t length = sizeof(peer);
+            const int fd = ::accept(listen_fd_, reinterpret_cast<sockaddr*>(&peer), &length);
+            if (fd < 0) {
+                return;
+            }
+            const int port = ntohs(peer.sin_port);
+            std::lock_guard<std::mutex> lock(mutex_);
+            handlers_.emplace_back([this, fd, port] { Serve(fd, port); });
+        }
+    }
+
+    // Reads one HTTP request (headers, then Content-Length bytes of body).
+    static bool ReadRequest(int fd) {
+        std::string buffer;
+        char chunk[1024];
+        size_t header_end = std::string::npos;
+        while (header_end == std::string::npos) {
+            const ssize_t n = ::recv(fd, chunk, sizeof(chunk), 0);
+            if (n <= 0) {
+                return false;
+            }
+            buffer.append(chunk, static_cast<size_t>(n));
+            header_end = buffer.find("\r\n\r\n");
+        }
+        size_t content_length = 0;
+        const size_t at = buffer.find("Content-Length:");
+        if (at != std::string::npos) {
+            content_length = static_cast<size_t>(std::atol(buffer.c_str() + at + 15));
+        }
+        size_t have = buffer.size() - (header_end + 4);
+        while (have < content_length) {
+            const ssize_t n = ::recv(fd, chunk, sizeof(chunk), 0);
+            if (n <= 0) {
+                return false;
+            }
+            have += static_cast<size_t>(n);
+        }
+        return true;
+    }
+
+    void Serve(int fd, int port) {
+        int answered = 0;
+        while (ReadRequest(fd)) {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                ports_.push_back(port);
+            }
+            if (answered > 0) {
+                // The half-open moment: the request was read, nothing comes
+                // back, the connection just ends.
+                break;
+            }
+            const std::string body = kJsonBody;
+            const std::string response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                                         "Content-Length: " + std::to_string(body.size()) +
+                                         "\r\nConnection: keep-alive\r\n\r\n" + body;
+            ::send(fd, response.data(), response.size(), 0);
+            ++answered;
+        }
+        ::close(fd);
+    }
+
+    int listen_fd_ = -1;
+    int port_ = 0;
+    std::thread acceptor_;
+    mutable std::mutex mutex_;
+    std::vector<std::thread> handlers_;
+    std::vector<int> ports_;
+};
+#endif
+
+std::string Describe(const std::vector<int>& ports) {
+    std::string out = "[";
+    for (size_t i = 0; i < ports.size(); ++i) {
+        out += (i ? ", " : "") + std::to_string(ports[i]);
+    }
+    return out + "]";
+}
+
+}  // namespace wally_tests
+
+#endif  // WALLY_TESTS_FAKE_UPSTREAM_H

--- a/tests/fake_upstream.h
+++ b/tests/fake_upstream.h
@@ -69,7 +69,7 @@ class FakeUpstream {
                              [this](size_t, httplib::DataSink& sink) {
                                  WaitForHold();
                                  const std::string body = kStreamBody;
-                                 if (die_) {
+                                 if (die_.load()) {
                                      size_t cut = body.find("\n\n");
                                      cut = body.find("\n\n", cut + 2) + 2;
                                      sink.write(body.data(), cut);
@@ -99,11 +99,11 @@ class FakeUpstream {
         return ports_;
     }
 
-    void hold_streams_until(int arrivals) { hold_until_ = arrivals; }
+    void hold_streams_until(int arrivals) { hold_until_.store(arrivals); }
 
     /// Send the first two SSE frames, then drop the connection without
     /// finishing the stream: an upstream that died mid-generation.
-    void die_mid_stream(bool on) { die_ = on; }
+    void die_mid_stream(bool on) { die_.store(on); }
 
    private:
     void Record(const httplib::Request& request) {
@@ -116,7 +116,7 @@ class FakeUpstream {
     void WaitForHold() {
         std::unique_lock<std::mutex> lock(mutex_);
         arrived_.wait_for(lock, std::chrono::seconds(5),
-                          [this] { return arrivals_ >= hold_until_; });
+                          [this] { return arrivals_ >= hold_until_.load(); });
     }
 
     httplib::Server server_;
@@ -126,8 +126,8 @@ class FakeUpstream {
     std::condition_variable arrived_;
     std::vector<int> ports_;
     int arrivals_ = 0;
-    int hold_until_ = 0;
-    bool die_ = false;
+    std::atomic<int> hold_until_{0};
+    std::atomic<bool> die_{false};
 };
 
 #if !defined(_WIN32)

--- a/tests/test_wally_anthropic.cpp
+++ b/tests/test_wally_anthropic.cpp
@@ -1,15 +1,15 @@
+#include "fake_upstream.h"
 #include "test_common.h"
 
+#include <httplib.h>
+
 #include <atomic>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <thread>
 #include <vector>
 
-#include <httplib.h>
-#include <nlohmann/json.hpp>
-
 #include "anthropic/messages.h"
-#include "fake_upstream.h"
 #include "harness/harness.h"
 #include "net/upstream_pool.h"
 
@@ -21,6 +21,54 @@ namespace {
 using Json = nlohmann::json;
 using wally_tests::Describe;
 using wally_tests::FakeUpstream;
+
+TestResult test_overload_headers_survive_streaming() {
+    TestResult result;
+    result.test_name = "overload_headers_survive_streaming";
+    httplib::Server server;
+    std::atomic<int> calls{0};
+    server.Post("/v1/chat/completions", [&](const httplib::Request& request,
+                                            httplib::Response& response) {
+        ++calls;
+        response.status = Json::parse(request.body).value("max_tokens", 429);
+        response.set_header("Retry-After", "7");
+        response.set_content(R"({"error":{"message":"capacity exhausted"}})", "application/json");
+    });
+    const int port = server.bind_to_any_port("127.0.0.1");
+    std::thread thread([&] { server.listen_after_bind(); });
+    server.wait_until_ready();
+    wally::harness::Endpoint endpoint;
+    endpoint.base_url = "http://127.0.0.1:" + std::to_string(port) + "/v1";
+    wally::anthropic::Shim shim;
+    const bool started = wally::anthropic::Start(endpoint, "test-model", &shim);
+    bool okay = started;
+    if (started) {
+        httplib::Client client(shim.base_url);
+        for (bool streaming : {false, true}) {
+            for (int status : {429, 503}) {
+                Json body{{"model", "test"},
+                          {"stream", streaming},
+                          {"max_tokens", status},
+                          {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
+                auto reply = client.Post("/v1/messages", {{"x-api-key", shim.auth_token}},
+                                         body.dump(), "application/json");
+                okay = okay && reply && reply->status == status &&
+                       reply->get_header_value("Retry-After") == "7" &&
+                       reply->get_header_value("Content-Type").find("application/json") == 0 &&
+                       reply->body.find("capacity exhausted") != std::string::npos;
+                result.actual += std::to_string(streaming) + ":" +
+                                 std::to_string(reply ? reply->status : 0) + ":" +
+                                 (reply ? reply->get_header_value("Retry-After") : "") + " ";
+            }
+        }
+    }
+    wally::anthropic::Stop(&shim);
+    server.stop();
+    thread.join();
+    result.passed = okay && calls == 4;
+    result.expected = "stream/nonstream preserve 429/503 and Retry-After: 7; one call each";
+    return result;
+}
 #if !defined(_WIN32)
 using wally_tests::HalfOpenUpstream;
 #endif
@@ -59,7 +107,6 @@ class RunningShim {
     bool started_ = false;
 };
 
-
 // Test A. Two requests, one after the other, must arrive at the upstream on
 // the same connection. Building a client per request (the behaviour #80
 // fixes) opens a new connection each time, so the ports differ.
@@ -77,8 +124,8 @@ TestResult test_sequential_requests_reuse_the_upstream_connection() {
     const std::vector<int> ports = upstream.ports();
     if (first != 200 || second != 200 || ports.size() != 2) {
         result.expected = "two 200s and two upstream requests";
-        result.actual = std::to_string(first) + ", " + std::to_string(second) + ", " +
-                        Describe(ports);
+        result.actual =
+            std::to_string(first) + ", " + std::to_string(second) + ", " + Describe(ports);
         return result;
     }
     result.passed = ports[0] == ports[1];
@@ -111,8 +158,8 @@ TestResult test_concurrent_requests_use_separate_connections() {
     const std::vector<int> ports = upstream.ports();
     if (first != 200 || second != 200 || ports.size() != 2) {
         result.expected = "two 200s and two upstream requests";
-        result.actual = std::to_string(first.load()) + ", " + std::to_string(second.load()) +
-                        ", " + Describe(ports);
+        result.actual = std::to_string(first.load()) + ", " + std::to_string(second.load()) + ", " +
+                        Describe(ports);
         return result;
     }
     result.passed = ports[0] != ports[1];
@@ -120,7 +167,6 @@ TestResult test_concurrent_requests_use_separate_connections() {
     result.actual = Describe(ports);
     return result;
 }
-
 
 // The pool on its own, no translator in front of it.
 TestResult test_pool_returns_a_clean_lease_and_drops_a_discarded_one() {
@@ -134,8 +180,8 @@ TestResult test_pool_returns_a_clean_lease_and_drops_a_discarded_one() {
         wally::net::UpstreamLease first = pool->acquire("k");
         if (first.reused() || pool->idle() != 0) {
             result.expected = "a fresh lease from an empty pool";
-            result.actual = "reused=" + std::to_string(first.reused()) + " idle=" +
-                            std::to_string(pool->idle());
+            result.actual = "reused=" + std::to_string(first.reused()) +
+                            " idle=" + std::to_string(pool->idle());
             return result;
         }
     }
@@ -218,7 +264,8 @@ TestResult test_retry_rule_only_on_a_stale_reused_connection() {
         {E::Read, false, true, true, false, "bytes reached the caller: never repeat"},
         {E::Timeout, false, false, true, false, "read timeout is not a stale socket"},
         {E::ConnectionTimeout, false, false, true, false, "connect timeout is the network"},
-        {E::SSLServerVerification, false, false, true, false, "certificate failure is not transient"},
+        {E::SSLServerVerification, false, false, true, false,
+         "certificate failure is not transient"},
         {E::Canceled, false, false, true, false, "a reader that left is not a stale socket"},
     };
     for (const Case& c : cases) {
@@ -232,7 +279,6 @@ TestResult test_retry_rule_only_on_a_stale_reused_connection() {
     result.passed = true;
     return result;
 }
-
 
 // Step 4a. A reused connection the far side has quietly stopped serving:
 // the request goes out, nothing comes back, the connection ends. The
@@ -263,8 +309,8 @@ TestResult test_stale_reused_connection_is_retried_once_on_a_fresh_one() {
     result.expected =
         "200, 200; three upstream requests, the first two on one connection, the third on another";
     result.actual = std::to_string(first) + ", " + std::to_string(second) + "; " + Describe(ports);
-    result.passed = first == 200 && second == 200 && ports.size() == 3 &&
-                    ports[0] == ports[1] && ports[2] != ports[0];
+    result.passed = first == 200 && second == 200 && ports.size() == 3 && ports[0] == ports[1] &&
+                    ports[2] != ports[0];
     return result;
 #endif
 }
@@ -294,8 +340,9 @@ TestResult test_upstream_dying_mid_stream_is_not_retried() {
     upstream.die_mid_stream(true);
     const int dying = shim.Send(true);
     const std::vector<int> ports = upstream.ports();
-    result.expected = "200, 200 (the error rides inside the stream); exactly two upstream "
-                      "requests on one connection";
+    result.expected =
+        "200, 200 (the error rides inside the stream); exactly two upstream "
+        "requests on one connection";
     result.actual = std::to_string(warm) + ", " + std::to_string(dying) + "; " + Describe(ports);
     result.passed = warm == 200 && dying == 200 && ports.size() == 2 && ports[0] == ports[1];
     return result;
@@ -305,6 +352,7 @@ TestResult test_upstream_dying_mid_stream_is_not_retried() {
 
 int main(int argc, char** argv) {
     TestSuite suite("wally_anthropic");
+    suite.add("overload_headers_survive_streaming", test_overload_headers_survive_streaming);
     suite.add("sequential_requests_reuse_the_upstream_connection",
               test_sequential_requests_reuse_the_upstream_connection);
     suite.add("concurrent_requests_use_separate_connections",

--- a/tests/test_wally_anthropic.cpp
+++ b/tests/test_wally_anthropic.cpp
@@ -31,7 +31,10 @@ TestResult test_overload_headers_survive_streaming() {
                                             httplib::Response& response) {
         ++calls;
         response.status = Json::parse(request.body).value("max_tokens", 429);
-        response.set_header("Retry-After", "7");
+        response.set_header("Retry-After", response.status == 429 ? "7" : "Wed, 21 Oct 2037 07:28:00 GMT");
+        if (request.get_header_value("Authorization") != "Bearer test-upstream-key") {
+            response.status = 401;
+        }
         response.set_content(R"({"error":{"message":"capacity exhausted"}})", "application/json");
     });
     const int port = server.bind_to_any_port("127.0.0.1");
@@ -39,6 +42,7 @@ TestResult test_overload_headers_survive_streaming() {
     server.wait_until_ready();
     wally::harness::Endpoint endpoint;
     endpoint.base_url = "http://127.0.0.1:" + std::to_string(port) + "/v1";
+    endpoint.api_key = "test-upstream-key";
     wally::anthropic::Shim shim;
     const bool started = wally::anthropic::Start(endpoint, "test-model", &shim);
     bool okay = started;
@@ -53,7 +57,8 @@ TestResult test_overload_headers_survive_streaming() {
                 auto reply = client.Post("/v1/messages", {{"x-api-key", shim.auth_token}},
                                          body.dump(), "application/json");
                 okay = okay && reply && reply->status == status &&
-                       reply->get_header_value("Retry-After") == "7" &&
+                       reply->get_header_value("Retry-After") ==
+                           (status == 429 ? "7" : "Wed, 21 Oct 2037 07:28:00 GMT") &&
                        reply->get_header_value("Content-Type").find("application/json") == 0 &&
                        reply->body.find("capacity exhausted") != std::string::npos;
                 result.actual += std::to_string(streaming) + ":" +
@@ -66,7 +71,7 @@ TestResult test_overload_headers_survive_streaming() {
     server.stop();
     thread.join();
     result.passed = okay && calls == 4;
-    result.expected = "stream/nonstream preserve 429/503 and Retry-After: 7; one call each";
+    result.expected = "stream/nonstream preserve 429/503 and numeric/date Retry-After; authenticated once each";
     return result;
 }
 #if !defined(_WIN32)

--- a/tests/test_wally_anthropic.cpp
+++ b/tests/test_wally_anthropic.cpp
@@ -1,9 +1,6 @@
 #include "test_common.h"
 
 #include <atomic>
-#include <chrono>
-#include <condition_variable>
-#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -12,113 +9,28 @@
 #include <nlohmann/json.hpp>
 
 #include "anthropic/messages.h"
+#include "fake_upstream.h"
 #include "harness/harness.h"
 #include "net/upstream_pool.h"
 
-// The translator's upstream connection behaviour, proven against a fake
-// OpenAI-shaped server on loopback. Every assertion here is about which TCP
-// connection a request arrived on, read from the server's side as the peer's
-// ephemeral port: the same port across requests means the same connection was
-// reused; a different port means a new connect (and, against the real
-// endpoint, a new TLS handshake). No network beyond 127.0.0.1, no models.
+// The Anthropic translator's upstream connection behaviour, against the fake
+// upstreams in fake_upstream.h.
 
 namespace {
 
 using Json = nlohmann::json;
-
-constexpr const char* kStreamBody =
-    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
-    "\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n"
-    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
-    "\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"
-    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
-    "\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
-    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],"
-    "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}\n\n"
-    "data: [DONE]\n\n";
-
-constexpr const char* kJsonBody =
-    "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"choices\":[{\"index\":0,"
-    "\"message\":{\"role\":\"assistant\",\"content\":\"hello\"},\"finish_reason\":\"stop\"}],"
-    "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}";
-
-/// An OpenAI-shaped upstream that remembers which connection each request
-/// arrived on. `hold_streams_until` makes streaming responses wait until that
-/// many requests have arrived before emitting anything, so two concurrent
-/// requests are provably in flight together rather than one finishing and
-/// lending its connection to the next.
-class FakeUpstream {
-   public:
-    FakeUpstream() {
-        server_.Post("/v1/chat/completions",
-                     [this](const httplib::Request& request, httplib::Response& response) {
-                         Record(request);
-                         const bool streaming = Json::parse(request.body).value("stream", false);
-                         if (!streaming) {
-                             response.set_content(kJsonBody, "application/json");
-                             return;
-                         }
-                         response.set_chunked_content_provider(
-                             "text/event-stream",
-                             [this](size_t, httplib::DataSink& sink) {
-                                 WaitForHold();
-                                 const std::string body = kStreamBody;
-                                 sink.write(body.data(), body.size());
-                                 sink.done();
-                                 return true;
-                             });
-                     });
-        port_ = server_.bind_to_any_port("127.0.0.1");
-        thread_ = std::thread([this] { server_.listen_after_bind(); });
-        server_.wait_until_ready();
-    }
-
-    ~FakeUpstream() {
-        server_.stop();
-        if (thread_.joinable()) {
-            thread_.join();
-        }
-    }
-
-    std::string base_url() const { return "http://127.0.0.1:" + std::to_string(port_) + "/v1"; }
-
-    std::vector<int> ports() const {
-        std::lock_guard<std::mutex> lock(mutex_);
-        return ports_;
-    }
-
-    void hold_streams_until(int arrivals) { hold_until_ = arrivals; }
-
-   private:
-    void Record(const httplib::Request& request) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        ports_.push_back(request.remote_port);
-        ++arrivals_;
-        arrived_.notify_all();
-    }
-
-    void WaitForHold() {
-        std::unique_lock<std::mutex> lock(mutex_);
-        arrived_.wait_for(lock, std::chrono::seconds(5),
-                          [this] { return arrivals_ >= hold_until_; });
-    }
-
-    httplib::Server server_;
-    std::thread thread_;
-    int port_ = 0;
-    mutable std::mutex mutex_;
-    std::condition_variable arrived_;
-    std::vector<int> ports_;
-    int arrivals_ = 0;
-    int hold_until_ = 0;
-};
+using wally_tests::Describe;
+using wally_tests::FakeUpstream;
+#if !defined(_WIN32)
+using wally_tests::HalfOpenUpstream;
+#endif
 
 /// A translator started against `upstream`, stopped on scope exit.
 class RunningShim {
    public:
-    explicit RunningShim(const FakeUpstream& upstream) {
+    explicit RunningShim(const std::string& upstream_base_url) {
         wally::harness::Endpoint endpoint;
-        endpoint.base_url = upstream.base_url();
+        endpoint.base_url = upstream_base_url;
         endpoint.api_key = "test-upstream-key";
         started_ = wally::anthropic::Start(endpoint, "glm-5.3", &shim_);
     }
@@ -147,13 +59,6 @@ class RunningShim {
     bool started_ = false;
 };
 
-std::string Describe(const std::vector<int>& ports) {
-    std::string out = "[";
-    for (size_t i = 0; i < ports.size(); ++i) {
-        out += (i ? ", " : "") + std::to_string(ports[i]);
-    }
-    return out + "]";
-}
 
 // Test A. Two requests, one after the other, must arrive at the upstream on
 // the same connection. Building a client per request (the behaviour #80
@@ -162,7 +67,7 @@ TestResult test_sequential_requests_reuse_the_upstream_connection() {
     TestResult result;
     result.test_name = "sequential_requests_reuse_the_upstream_connection";
     FakeUpstream upstream;
-    RunningShim shim(upstream);
+    RunningShim shim(upstream.base_url());
     if (!shim.started()) {
         result.details = "translator did not start";
         return result;
@@ -192,7 +97,7 @@ TestResult test_concurrent_requests_use_separate_connections() {
     result.test_name = "concurrent_requests_use_separate_connections";
     FakeUpstream upstream;
     upstream.hold_streams_until(2);
-    RunningShim shim(upstream);
+    RunningShim shim(upstream.base_url());
     if (!shim.started()) {
         result.details = "translator did not start";
         return result;
@@ -314,6 +219,7 @@ TestResult test_retry_rule_only_on_a_stale_reused_connection() {
         {E::Timeout, false, false, true, false, "read timeout is not a stale socket"},
         {E::ConnectionTimeout, false, false, true, false, "connect timeout is the network"},
         {E::SSLServerVerification, false, false, true, false, "certificate failure is not transient"},
+        {E::Canceled, false, false, true, false, "a reader that left is not a stale socket"},
     };
     for (const Case& c : cases) {
         const bool got = RetryOnFreshConnection(c.error, c.has_response, c.received_any, c.reused);
@@ -324,6 +230,74 @@ TestResult test_retry_rule_only_on_a_stale_reused_connection() {
         }
     }
     result.passed = true;
+    return result;
+}
+
+
+// Step 4a. A reused connection the far side has quietly stopped serving:
+// the request goes out, nothing comes back, the connection ends. The
+// translator must try once more on a fresh connection and answer 200, and the
+// upstream must see exactly three requests: the first (answered), the stale
+// one (dropped), and the retry (answered) on a NEW connection.
+TestResult test_stale_reused_connection_is_retried_once_on_a_fresh_one() {
+    TestResult result;
+    result.test_name = "stale_reused_connection_is_retried_once_on_a_fresh_one";
+#if defined(_WIN32)
+    result.passed = true;
+    result.details = "skipped: raw-socket fake upstream is POSIX-only";
+    return result;
+#else
+    HalfOpenUpstream upstream;
+    if (!upstream.ok()) {
+        result.details = "could not bind the half-open upstream";
+        return result;
+    }
+    RunningShim shim(upstream.base_url());
+    if (!shim.started()) {
+        result.details = "translator did not start";
+        return result;
+    }
+    const int first = shim.Send(false);
+    const int second = shim.Send(false);
+    const std::vector<int> ports = upstream.ports();
+    result.expected =
+        "200, 200; three upstream requests, the first two on one connection, the third on another";
+    result.actual = std::to_string(first) + ", " + std::to_string(second) + "; " + Describe(ports);
+    result.passed = first == 200 && second == 200 && ports.size() == 3 &&
+                    ports[0] == ports[1] && ports[2] != ports[0];
+    return result;
+#endif
+}
+
+// Step 4b. The case received_any exists for: a REUSED connection whose far
+// side dies after it has started answering. The error is connection-class
+// and there is no status, so only the "bytes reached the caller" rule stops
+// a retry -- and a retry would run the generation twice. The upstream must
+// see exactly two requests: the one that warmed the connection and the one
+// that died on it.
+//
+// (An "editor abandons the stream" variant was tried and removed: on loopback
+// the translator's writes to the closed reader keep succeeding for longer than
+// the stream lasts, so that test could not observe the abort path and passed
+// for the wrong reason. Abandonment is Error::Canceled, which the retry table
+// test covers.)
+TestResult test_upstream_dying_mid_stream_is_not_retried() {
+    TestResult result;
+    result.test_name = "upstream_dying_mid_stream_is_not_retried";
+    FakeUpstream upstream;
+    RunningShim shim(upstream.base_url());
+    if (!shim.started()) {
+        result.details = "translator did not start";
+        return result;
+    }
+    const int warm = shim.Send(false);
+    upstream.die_mid_stream(true);
+    const int dying = shim.Send(true);
+    const std::vector<int> ports = upstream.ports();
+    result.expected = "200, 200 (the error rides inside the stream); exactly two upstream "
+                      "requests on one connection";
+    result.actual = std::to_string(warm) + ", " + std::to_string(dying) + "; " + Describe(ports);
+    result.passed = warm == 200 && dying == 200 && ports.size() == 2 && ports[0] == ports[1];
     return result;
 }
 
@@ -340,5 +314,9 @@ int main(int argc, char** argv) {
     suite.add("pool_outlives_an_outstanding_lease", test_pool_outlives_an_outstanding_lease);
     suite.add("retry_rule_only_on_a_stale_reused_connection",
               test_retry_rule_only_on_a_stale_reused_connection);
+    suite.add("stale_reused_connection_is_retried_once_on_a_fresh_one",
+              test_stale_reused_connection_is_retried_once_on_a_fresh_one);
+    suite.add("upstream_dying_mid_stream_is_not_retried",
+              test_upstream_dying_mid_stream_is_not_retried);
     return suite.run(argc, argv);
 }

--- a/tests/test_wally_anthropic.cpp
+++ b/tests/test_wally_anthropic.cpp
@@ -1,0 +1,344 @@
+#include "test_common.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "anthropic/messages.h"
+#include "harness/harness.h"
+#include "net/upstream_pool.h"
+
+// The translator's upstream connection behaviour, proven against a fake
+// OpenAI-shaped server on loopback. Every assertion here is about which TCP
+// connection a request arrived on, read from the server's side as the peer's
+// ephemeral port: the same port across requests means the same connection was
+// reused; a different port means a new connect (and, against the real
+// endpoint, a new TLS handshake). No network beyond 127.0.0.1, no models.
+
+namespace {
+
+using Json = nlohmann::json;
+
+constexpr const char* kStreamBody =
+    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
+    "\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n"
+    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
+    "\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"
+    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
+    "\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
+    "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[],"
+    "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}\n\n"
+    "data: [DONE]\n\n";
+
+constexpr const char* kJsonBody =
+    "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"choices\":[{\"index\":0,"
+    "\"message\":{\"role\":\"assistant\",\"content\":\"hello\"},\"finish_reason\":\"stop\"}],"
+    "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}";
+
+/// An OpenAI-shaped upstream that remembers which connection each request
+/// arrived on. `hold_streams_until` makes streaming responses wait until that
+/// many requests have arrived before emitting anything, so two concurrent
+/// requests are provably in flight together rather than one finishing and
+/// lending its connection to the next.
+class FakeUpstream {
+   public:
+    FakeUpstream() {
+        server_.Post("/v1/chat/completions",
+                     [this](const httplib::Request& request, httplib::Response& response) {
+                         Record(request);
+                         const bool streaming = Json::parse(request.body).value("stream", false);
+                         if (!streaming) {
+                             response.set_content(kJsonBody, "application/json");
+                             return;
+                         }
+                         response.set_chunked_content_provider(
+                             "text/event-stream",
+                             [this](size_t, httplib::DataSink& sink) {
+                                 WaitForHold();
+                                 const std::string body = kStreamBody;
+                                 sink.write(body.data(), body.size());
+                                 sink.done();
+                                 return true;
+                             });
+                     });
+        port_ = server_.bind_to_any_port("127.0.0.1");
+        thread_ = std::thread([this] { server_.listen_after_bind(); });
+        server_.wait_until_ready();
+    }
+
+    ~FakeUpstream() {
+        server_.stop();
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    std::string base_url() const { return "http://127.0.0.1:" + std::to_string(port_) + "/v1"; }
+
+    std::vector<int> ports() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return ports_;
+    }
+
+    void hold_streams_until(int arrivals) { hold_until_ = arrivals; }
+
+   private:
+    void Record(const httplib::Request& request) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        ports_.push_back(request.remote_port);
+        ++arrivals_;
+        arrived_.notify_all();
+    }
+
+    void WaitForHold() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        arrived_.wait_for(lock, std::chrono::seconds(5),
+                          [this] { return arrivals_ >= hold_until_; });
+    }
+
+    httplib::Server server_;
+    std::thread thread_;
+    int port_ = 0;
+    mutable std::mutex mutex_;
+    std::condition_variable arrived_;
+    std::vector<int> ports_;
+    int arrivals_ = 0;
+    int hold_until_ = 0;
+};
+
+/// A translator started against `upstream`, stopped on scope exit.
+class RunningShim {
+   public:
+    explicit RunningShim(const FakeUpstream& upstream) {
+        wally::harness::Endpoint endpoint;
+        endpoint.base_url = upstream.base_url();
+        endpoint.api_key = "test-upstream-key";
+        started_ = wally::anthropic::Start(endpoint, "glm-5.3", &shim_);
+    }
+    ~RunningShim() { wally::anthropic::Stop(&shim_); }
+
+    bool started() const { return started_; }
+    const wally::anthropic::Shim& shim() const { return shim_; }
+
+    /// One Anthropic-shaped request through the translator; the status it
+    /// answered with, or 0 when nothing came back.
+    int Send(bool streaming) const {
+        httplib::Client client(shim_.base_url);
+        client.set_read_timeout(10, 0);
+        const Json body{{"model", "claude-x"},
+                        {"max_tokens", 16},
+                        {"stream", streaming},
+                        {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
+        const httplib::Result reply =
+            client.Post("/v1/messages", {{"Authorization", "Bearer " + shim_.auth_token}},
+                        body.dump(), "application/json");
+        return reply ? reply->status : 0;
+    }
+
+   private:
+    wally::anthropic::Shim shim_;
+    bool started_ = false;
+};
+
+std::string Describe(const std::vector<int>& ports) {
+    std::string out = "[";
+    for (size_t i = 0; i < ports.size(); ++i) {
+        out += (i ? ", " : "") + std::to_string(ports[i]);
+    }
+    return out + "]";
+}
+
+// Test A. Two requests, one after the other, must arrive at the upstream on
+// the same connection. Building a client per request (the behaviour #80
+// fixes) opens a new connection each time, so the ports differ.
+TestResult test_sequential_requests_reuse_the_upstream_connection() {
+    TestResult result;
+    result.test_name = "sequential_requests_reuse_the_upstream_connection";
+    FakeUpstream upstream;
+    RunningShim shim(upstream);
+    if (!shim.started()) {
+        result.details = "translator did not start";
+        return result;
+    }
+    const int first = shim.Send(true);
+    const int second = shim.Send(false);
+    const std::vector<int> ports = upstream.ports();
+    if (first != 200 || second != 200 || ports.size() != 2) {
+        result.expected = "two 200s and two upstream requests";
+        result.actual = std::to_string(first) + ", " + std::to_string(second) + ", " +
+                        Describe(ports);
+        return result;
+    }
+    result.passed = ports[0] == ports[1];
+    result.expected = "same peer port on both upstream requests (one connection)";
+    result.actual = Describe(ports);
+    return result;
+}
+
+// Test B. Two requests in flight at once must NOT share a connection: an
+// httplib client serialises requests on its socket, so a single shared client
+// would queue the second stream behind the first. The upstream holds both
+// streams until both have arrived, so a finished stream cannot lend its
+// connection and make the test pass by legitimate reuse.
+TestResult test_concurrent_requests_use_separate_connections() {
+    TestResult result;
+    result.test_name = "concurrent_requests_use_separate_connections";
+    FakeUpstream upstream;
+    upstream.hold_streams_until(2);
+    RunningShim shim(upstream);
+    if (!shim.started()) {
+        result.details = "translator did not start";
+        return result;
+    }
+    std::atomic<int> first{0};
+    std::atomic<int> second{0};
+    std::thread a([&] { first = shim.Send(true); });
+    std::thread b([&] { second = shim.Send(true); });
+    a.join();
+    b.join();
+    const std::vector<int> ports = upstream.ports();
+    if (first != 200 || second != 200 || ports.size() != 2) {
+        result.expected = "two 200s and two upstream requests";
+        result.actual = std::to_string(first.load()) + ", " + std::to_string(second.load()) +
+                        ", " + Describe(ports);
+        return result;
+    }
+    result.passed = ports[0] != ports[1];
+    result.expected = "different peer ports (two connections in flight)";
+    result.actual = Describe(ports);
+    return result;
+}
+
+
+// The pool on its own, no translator in front of it.
+TestResult test_pool_returns_a_clean_lease_and_drops_a_discarded_one() {
+    TestResult result;
+    result.test_name = "pool_returns_a_clean_lease_and_drops_a_discarded_one";
+    wally::net::UpstreamOptions options;
+    options.origin = "http://127.0.0.1:9";
+    options.idle_limit = 2;
+    auto pool = std::make_shared<wally::net::UpstreamPool>(options);
+    {
+        wally::net::UpstreamLease first = pool->acquire("k");
+        if (first.reused() || pool->idle() != 0) {
+            result.expected = "a fresh lease from an empty pool";
+            result.actual = "reused=" + std::to_string(first.reused()) + " idle=" +
+                            std::to_string(pool->idle());
+            return result;
+        }
+    }
+    if (pool->idle() != 1) {
+        result.expected = "1 idle client after a clean lease ends";
+        result.actual = std::to_string(pool->idle());
+        return result;
+    }
+    {
+        wally::net::UpstreamLease second = pool->acquire("k");
+        if (!second.reused()) {
+            result.expected = "the idle client reused";
+            result.actual = "a fresh client";
+            return result;
+        }
+        second.discard();
+    }
+    if (pool->idle() != 0) {
+        result.expected = "0 idle after a discarded lease ends";
+        result.actual = std::to_string(pool->idle());
+        return result;
+    }
+    // Three clean leases at once, then returned: the idle set stops at the limit.
+    {
+        wally::net::UpstreamLease a = pool->acquire("k");
+        wally::net::UpstreamLease b = pool->acquire("k");
+        wally::net::UpstreamLease c = pool->acquire("k");
+    }
+    result.passed = pool->idle() == 2;
+    result.expected = "idle capped at 2";
+    result.actual = std::to_string(pool->idle());
+    return result;
+}
+
+// A pool outlives its leases: dropping the last shared_ptr while a lease is
+// out must not leave the lease pointing at freed memory.
+TestResult test_pool_outlives_an_outstanding_lease() {
+    TestResult result;
+    result.test_name = "pool_outlives_an_outstanding_lease";
+    wally::net::UpstreamOptions options;
+    options.origin = "http://127.0.0.1:9";
+    auto pool = std::make_shared<wally::net::UpstreamPool>(options);
+    std::weak_ptr<wally::net::UpstreamPool> weak = pool;
+    {
+        wally::net::UpstreamLease lease = pool->acquire("k");
+        pool.reset();
+        if (weak.expired()) {
+            result.expected = "pool alive while a lease is out";
+            result.actual = "expired";
+            return result;
+        }
+    }
+    result.passed = weak.expired();
+    result.expected = "pool freed once the last lease returned";
+    result.actual = weak.expired() ? "freed" : "still alive";
+    return result;
+}
+
+TestResult test_retry_rule_only_on_a_stale_reused_connection() {
+    TestResult result;
+    result.test_name = "retry_rule_only_on_a_stale_reused_connection";
+    using wally::net::RetryOnFreshConnection;
+    using E = httplib::Error;
+    struct Case {
+        E error;
+        bool has_response;
+        bool received_any;
+        bool reused;
+        bool expect;
+        const char* why;
+    };
+    const Case cases[] = {
+        {E::Read, false, false, true, true, "stale reused socket, nothing back"},
+        {E::Connection, false, false, true, true, "reused, connect-class error"},
+        {E::ConnectionClosed, false, false, true, true, "reused, closed by peer"},
+        {E::Write, false, false, true, true, "reused, write failed"},
+        {E::SSLConnection, false, false, true, true, "reused, TLS layer reset"},
+        {E::Read, false, false, false, false, "fresh connection: a real outage surfaces"},
+        {E::Read, true, false, true, false, "a status arrived: never repeat"},
+        {E::Read, false, true, true, false, "bytes reached the caller: never repeat"},
+        {E::Timeout, false, false, true, false, "read timeout is not a stale socket"},
+        {E::ConnectionTimeout, false, false, true, false, "connect timeout is the network"},
+        {E::SSLServerVerification, false, false, true, false, "certificate failure is not transient"},
+    };
+    for (const Case& c : cases) {
+        const bool got = RetryOnFreshConnection(c.error, c.has_response, c.received_any, c.reused);
+        if (got != c.expect) {
+            result.expected = std::string(c.why) + " -> " + (c.expect ? "retry" : "no retry");
+            result.actual = got ? "retry" : "no retry";
+            return result;
+        }
+    }
+    result.passed = true;
+    return result;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    TestSuite suite("wally_anthropic");
+    suite.add("sequential_requests_reuse_the_upstream_connection",
+              test_sequential_requests_reuse_the_upstream_connection);
+    suite.add("concurrent_requests_use_separate_connections",
+              test_concurrent_requests_use_separate_connections);
+    suite.add("pool_returns_a_clean_lease_and_drops_a_discarded_one",
+              test_pool_returns_a_clean_lease_and_drops_a_discarded_one);
+    suite.add("pool_outlives_an_outstanding_lease", test_pool_outlives_an_outstanding_lease);
+    suite.add("retry_rule_only_on_a_stale_reused_connection",
+              test_retry_rule_only_on_a_stale_reused_connection);
+    return suite.run(argc, argv);
+}

--- a/tests/test_wally_ide_proxy.cpp
+++ b/tests/test_wally_ide_proxy.cpp
@@ -27,10 +27,18 @@ using wally_tests::HalfOpenUpstream;
 
 /// A port nothing is listening on right now. StartProxy needs a real number:
 /// it writes the address into the editor's settings, so 0 is not an option.
+///
+/// The probe has to actually listen and then stop: httplib's stop() closes
+/// the listening socket only while the server is running, and its destructor
+/// does not close it at all, so a bind-and-drop probe leaks a listening
+/// socket per call.
 int FreePort() {
     httplib::Server probe;
     const int port = probe.bind_to_any_port("127.0.0.1");
+    std::thread listener([&probe] { probe.listen_after_bind(); });
+    probe.wait_until_ready();
     probe.stop();
+    listener.join();
     return port;
 }
 

--- a/tests/test_wally_ide_proxy.cpp
+++ b/tests/test_wally_ide_proxy.cpp
@@ -1,0 +1,133 @@
+#include "test_common.h"
+
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "fake_upstream.h"
+#include "harness/harness.h"
+#include "ide/openai_proxy.h"
+
+// The JetBrains proxy's upstream connection behaviour (wally #80), against
+// the fake upstreams in fake_upstream.h. Same properties as the Anthropic
+// translator's suite: one connection across sequential requests, and a
+// stale reused connection tried once more on a fresh one.
+
+namespace {
+
+using Json = nlohmann::json;
+using wally_tests::Describe;
+using wally_tests::FakeUpstream;
+#if !defined(_WIN32)
+using wally_tests::HalfOpenUpstream;
+#endif
+
+/// A port nothing is listening on right now. StartProxy needs a real number:
+/// it writes the address into the editor's settings, so 0 is not an option.
+int FreePort() {
+    httplib::Server probe;
+    const int port = probe.bind_to_any_port("127.0.0.1");
+    probe.stop();
+    return port;
+}
+
+/// A proxy started against `upstream_base_url`, stopped on scope exit.
+class RunningProxy {
+   public:
+    explicit RunningProxy(const std::string& upstream_base_url) {
+        wally::harness::Endpoint endpoint;
+        endpoint.base_url = upstream_base_url;
+        endpoint.api_key = "test-upstream-key";
+        started_ = wally::ide::StartProxy(endpoint, "glm-5.3", FreePort(), &proxy_, false);
+    }
+    ~RunningProxy() { wally::ide::StopProxy(&proxy_); }
+
+    bool started() const { return started_; }
+
+    /// One OpenAI-shaped request through the proxy; the status it answered
+    /// with, or 0 when nothing came back.
+    int Send(bool streaming) const {
+        httplib::Client client(proxy_.base_url);
+        client.set_read_timeout(10, 0);
+        const Json body{{"model", "anything"},
+                        {"stream", streaming},
+                        {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
+        const httplib::Result reply =
+            client.Post("/v1/chat/completions",
+                        {{"Authorization", "Bearer " + proxy_.auth_token}},
+                        body.dump(), "application/json");
+        return reply ? reply->status : 0;
+    }
+
+   private:
+    wally::ide::Proxy proxy_;
+    bool started_ = false;
+};
+
+TestResult test_proxy_sequential_requests_reuse_the_upstream_connection() {
+    TestResult result;
+    result.test_name = "proxy_sequential_requests_reuse_the_upstream_connection";
+    FakeUpstream upstream;
+    RunningProxy proxy(upstream.base_url());
+    if (!proxy.started()) {
+        result.details = "proxy did not start";
+        return result;
+    }
+    const int first = proxy.Send(true);
+    const int second = proxy.Send(false);
+    const std::vector<int> ports = upstream.ports();
+    if (first != 200 || second != 200 || ports.size() != 2) {
+        result.expected = "two 200s and two upstream requests";
+        result.actual = std::to_string(first) + ", " + std::to_string(second) + ", " +
+                        Describe(ports);
+        return result;
+    }
+    result.passed = ports[0] == ports[1];
+    result.expected = "same peer port on both upstream requests (one connection)";
+    result.actual = Describe(ports);
+    return result;
+}
+
+TestResult test_proxy_stale_reused_connection_is_retried_once() {
+    TestResult result;
+    result.test_name = "proxy_stale_reused_connection_is_retried_once";
+#if defined(_WIN32)
+    result.passed = true;
+    result.details = "skipped: raw-socket fake upstream is POSIX-only";
+    return result;
+#else
+    HalfOpenUpstream upstream;
+    if (!upstream.ok()) {
+        result.details = "could not bind the half-open upstream";
+        return result;
+    }
+    RunningProxy proxy(upstream.base_url());
+    if (!proxy.started()) {
+        result.details = "proxy did not start";
+        return result;
+    }
+    const int first = proxy.Send(false);
+    const int second = proxy.Send(false);
+    const std::vector<int> ports = upstream.ports();
+    result.expected =
+        "200, 200; three upstream requests, the first two on one connection, the third on another";
+    result.actual = std::to_string(first) + ", " + std::to_string(second) + "; " + Describe(ports);
+    result.passed = first == 200 && second == 200 && ports.size() == 3 &&
+                    ports[0] == ports[1] && ports[2] != ports[0];
+    return result;
+#endif
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    TestSuite suite("wally_ide_proxy");
+    suite.add("proxy_sequential_requests_reuse_the_upstream_connection",
+              test_proxy_sequential_requests_reuse_the_upstream_connection);
+    suite.add("proxy_stale_reused_connection_is_retried_once",
+              test_proxy_stale_reused_connection_is_retried_once);
+    return suite.run(argc, argv);
+}


### PR DESCRIPTION
Streaming `/v1/messages` now waits for upstream HTTP headers before committing downstream SSE. A pre-stream 429 or 503 remains that HTTP status, with the original numeric or HTTP-date `Retry-After` and a typed Anthropic JSON error. Previously both became HTTP 200 with an SSE error and no cooldown header; nonstream 503 also lost its cooldown.

Related to #83. The issue remains open for owner acceptance and deployment testing.

The implementation uses cpp-httplib's response-header callback on the existing pooled connection. One bounded chunk slot connects the upstream reader to the downstream writer, preserving backpressure without buffering the full generation. Failed or abandoned streams discard the socket. A connection failure after receiving HTTP headers is never retried as a stale socket; mid-stream failures retain typed SSE errors and are not replayed.

Validation:

- Regression red on PR #82 (`ded8a74`): streaming 429 and 503 both returned 200 without Retry-After; nonstream 503 lost Retry-After. Existing seven transport tests passed.
- Regression green: actual loopback HTTP requests preserve 429/503, numeric/date Retry-After, upstream bearer authentication, typed JSON, and exactly one upstream request per refusal.
- Complete macOS C++ build against verified pinned SDK kit 0.20.37; `ctest --test-dir build --output-on-failure`: 12/12 passed. Existing transport tests cover successful streaming, separate concurrent connections, pooled reuse, stale connection retry and no mid-stream replay.
- `scripts/ci/check-agents-sync.sh` and `scripts/test/smoke.sh build/wally-cxx` passed.
- Apple MLX product-host build and Windows binary were not exercised; this was the C++ build with `WALLY_APPLE_MLX_HOST=OFF`, explicit OpenSSL root. Optional live/model tests retain their existing internal skips. No real API credentials or paid inference were used. Exact Claude Code retry timing and deployed gateway behavior still require final owner E2E acceptance.

Merge sequence: PR #82 → this PR → the separate #84 terminal-stream validation PR. Current base is `issue-80-shim-keepalive`; final integration target is `main` (this repository has no dev/development branch). After #82 merges, rebase this branch onto `main` and retarget, particularly if #82 is squash-merged. Siddhesh owns merging. Coordinate Aman's active #81 cancellation work against this updated transport; this PR does not implement the explicit remote cancel API. No automatic issue-closing keywords are used.
