### PR TITLE
anthropic: keep the upstream status and Retry-After on the streaming path

### DIFF
--- a/src/anthropic/messages.cpp
+++ b/src/anthropic/messages.cpp
@@ -2,10 +2,14 @@
 
 #include <algorithm>
 #include <atomic>
+#include <condition_variable>
+#include <cstddef>
 #include <ctime>
+#include <deque>
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -168,102 +172,257 @@ void HandleNonStreaming(Runtime& runtime, const Json& request, httplib::Response
                          "application/json");
 }
 
-void HandleStreaming(Runtime& runtime, const Json& request, httplib::Response& response) {
-    // The upstream body is built here rather than in the sink: the sink runs
-    // after this function returns, and everything it touches has to outlive it.
-    auto upstream = std::make_shared<std::string>(
-        translate::RequestToOpenAI(request, runtime.model).dump());
-    auto origin = std::make_shared<std::string>(runtime.origin);
-    auto path = std::make_shared<std::string>(runtime.prefix + "/chat/completions");
-    auto api_key = std::make_shared<std::string>(runtime.api_key);
-    auto model = std::make_shared<std::string>(runtime.model);
+// A streaming upstream call whose HTTP status is known before anything has been
+// written downstream.
+//
+// The shim used to commit a 200 and only then make the call, because the chunked
+// content provider runs after the request handler returns. An upstream 429 with a
+// Retry-After therefore reached the editor as a 200 carrying an SSE error, with the
+// delay gone (#83). Running the call on its own thread lets the handler wait for the
+// upstream headers, which is the only thing it needs in order to answer honestly, and
+// still start writing on the first token rather than buffering the whole reply.
+struct StreamPump {
+    std::mutex mutex;
+    // Headers have landed, an event is queued, or the worker is finished.
+    std::condition_variable ready;
+    // The queue has fallen back under the cap.
+    std::condition_variable drained;
 
-    response.set_chunked_content_provider(
-        "text/event-stream",
-        [upstream, origin, path, api_key, model](size_t /*offset*/, httplib::DataSink& sink) {
-            httplib::Client client(*origin);
-            client.set_read_timeout(600, 0);
-            ApplyAuth(client, *api_key);
+    // Translated Anthropic SSE, in the order it is to be written.
+    std::deque<std::string> events;
+    std::size_t queued_bytes = 0;
 
-            translate::StreamState state;
-            state.model = *model;
-            std::string pending;
-            // The upstream status is only known once Post returns, so the start
-            // of the body is kept regardless. On a non-2xx reply that is the
-            // error body, which would otherwise be fed to the SSE frame parser
-            // and silently dropped; capped so a real (2xx) stream of any size
-            // costs only these few KB.
-            std::string error_body;
-            constexpr size_t kErrorBodyCap = 8192;
+    bool headers_known = false;
+    bool finished = false;
+    // The reader went away; the worker stops at its next chunk.
+    bool cancelled = false;
 
-            const httplib::Result reply = client.Post(
-                *path, httplib::Headers(), *upstream, "application/json",
-                [&](const char* data, size_t length) {
-                    if (error_body.size() < kErrorBodyCap) {
-                        error_body.append(data,
-                                          std::min(length, kErrorBodyCap - error_body.size()));
-                    }
-                    pending.append(data, length);
-                    // SSE frames are separated by a blank line, and a chunk can
-                    // split one in half, so only whole frames are consumed.
-                    size_t split = 0;
-                    while ((split = pending.find("\n\n")) != std::string::npos) {
-                        const std::string frame = pending.substr(0, split);
-                        pending.erase(0, split + 2);
-                        const size_t field = frame.find("data:");
-                        if (field == std::string::npos) {
-                            continue;
-                        }
-                        std::string payload = frame.substr(field + 5);
-                        while (!payload.empty() && (payload.front() == ' ' || payload.front() == '\r')) {
-                            payload.erase(payload.begin());
-                        }
-                        if (payload == "[DONE]") {
-                            continue;
-                        }
-                        Json chunk;
-                        try {
-                            chunk = Json::parse(payload);
-                        } catch (const Json::exception&) {
-                            continue;
-                        }
-                        std::string events;
-                        try {
-                            events = translate::StreamChunkToAnthropic(chunk, &state);
-                        } catch (const std::exception&) {
-                            // A chunk in a shape the mapping did not expect is
-                            // a chunk to skip, not a reason to kill the run.
-                            continue;
-                        }
-                        if (!events.empty() && !sink.write(events.data(), events.size())) {
-                            return false;
-                        }
-                    }
-                    return true;
-                });
+    int status = 0;
+    std::string retry_after;
+    // Kept only for a non-2xx reply, where the body is the error rather than a
+    // stream. Capped so a real stream of any size costs nothing here.
+    std::string error_body;
+};
 
-            if (!reply || reply->status < 200 || reply->status >= 300) {
-                const int status = reply ? reply->status : 0;
-                LogUpstreamError(*model, true, status, error_body);
-                std::string type;
-                std::string message;
-                translate::UpstreamFailure(status, error_body, &type, &message);
-                const std::string body =
-                    "event: error\ndata: " + translate::ErrorBody(type, message) + "\n\n";
-                sink.write(body.data(), body.size());
-                sink.done();
-                return false;
+constexpr std::size_t kErrorBodyCap = 8192;
+// A slow editor must not let a fast endpoint grow the queue without bound.
+constexpr std::size_t kQueuedBytesCap = 4 * 1024 * 1024;
+
+void PumpEvents(const std::shared_ptr<StreamPump>& pump, std::string events) {
+    if (events.empty()) {
+        return;
+    }
+    std::unique_lock<std::mutex> lock(pump->mutex);
+    pump->drained.wait(lock, [&] { return pump->cancelled || pump->queued_bytes < kQueuedBytesCap; });
+    if (pump->cancelled) {
+        return;
+    }
+    pump->queued_bytes += events.size();
+    pump->events.push_back(std::move(events));
+    pump->ready.notify_all();
+}
+
+// Runs on the worker thread. Everything the translator touches — the stream state
+// and the half-frame buffer — lives here, so the mapping is still single-threaded.
+void RunUpstream(const std::shared_ptr<StreamPump>& pump, const std::string& origin,
+                 const std::string& path, const std::string& api_key, const std::string& model,
+                 const std::string& body) {
+    httplib::Client client(origin);
+    client.set_read_timeout(600, 0);
+    ApplyAuth(client, api_key);
+
+    translate::StreamState state;
+    state.model = model;
+    std::string pending;
+    bool upstream_ok = false;
+
+    httplib::Request request;
+    request.method = "POST";
+    request.path = path;
+    request.body = body;
+    request.set_header("Content-Type", "application/json");
+
+    request.response_handler = [&](const httplib::Response& reply) {
+        {
+            std::lock_guard<std::mutex> lock(pump->mutex);
+            pump->status = reply.status;
+            if (reply.has_header("Retry-After")) {
+                pump->retry_after = reply.get_header_value("Retry-After");
             }
+            pump->headers_known = true;
+            pump->ready.notify_all();
+        }
+        upstream_ok = reply.status >= 200 && reply.status < 300;
+        return true;
+    };
+
+    request.content_receiver = [&](const char* data, std::size_t length, std::size_t, std::size_t) {
+        if (!upstream_ok) {
+            std::lock_guard<std::mutex> lock(pump->mutex);
+            if (pump->error_body.size() < kErrorBodyCap) {
+                pump->error_body.append(data,
+                                        std::min(length, kErrorBodyCap - pump->error_body.size()));
+            }
+            return true;
+        }
+        pending.append(data, length);
+        // SSE frames are separated by a blank line, and a chunk can split one in
+        // half, so only whole frames are consumed.
+        std::size_t split = 0;
+        while ((split = pending.find("\n\n")) != std::string::npos) {
+            const std::string frame = pending.substr(0, split);
+            pending.erase(0, split + 2);
+            const std::size_t field = frame.find("data:");
+            if (field == std::string::npos) {
+                continue;
+            }
+            std::string payload = frame.substr(field + 5);
+            while (!payload.empty() && (payload.front() == ' ' || payload.front() == '\r')) {
+                payload.erase(payload.begin());
+            }
+            if (payload == "[DONE]") {
+                continue;
+            }
+            Json chunk;
             try {
-                const std::string closing = translate::StreamCloseToAnthropic(&state);
-                if (!closing.empty()) {
-                    sink.write(closing.data(), closing.size());
-                }
+                chunk = Json::parse(payload);
+            } catch (const Json::exception&) {
+                continue;
+            }
+            std::string events;
+            try {
+                events = translate::StreamChunkToAnthropic(chunk, &state);
+            } catch (const std::exception&) {
+                // A chunk in a shape the mapping did not expect is a chunk to
+                // skip, not a reason to kill the run.
+                continue;
+            }
+            PumpEvents(pump, std::move(events));
+        }
+        std::lock_guard<std::mutex> lock(pump->mutex);
+        return !pump->cancelled;
+    };
+
+    const httplib::Result reply = client.send(request);
+    const bool transport_ok = static_cast<bool>(reply);
+
+    {
+        std::lock_guard<std::mutex> lock(pump->mutex);
+        if (!pump->headers_known) {
+            // The call failed before any reply: no status was ever seen.
+            pump->status = reply ? reply->status : 0;
+            pump->headers_known = true;
+        }
+    }
+
+    if (upstream_ok) {
+        if (transport_ok) {
+            try {
+                std::string closing = translate::StreamCloseToAnthropic(&state);
+                PumpEvents(pump, std::move(closing));
             } catch (const std::exception&) {
                 // Nothing useful left to say; ending the stream cleanly beats
                 // aborting the process holding the reader's editor open.
             }
-            sink.done();
+        } else {
+            // The status is already spent on a 200, so a failure this late can
+            // only be a typed SSE error. It must not read as a normal stop.
+            LogUpstreamError(model, true, 0, "upstream stream ended early");
+            std::string type;
+            std::string message;
+            translate::UpstreamFailure(0, std::string(), &type, &message);
+            PumpEvents(pump, "event: error\ndata: " + translate::ErrorBody(type, message) + "\n\n");
+        }
+    }
+
+    std::lock_guard<std::mutex> lock(pump->mutex);
+    pump->finished = true;
+    pump->ready.notify_all();
+}
+
+// Stops the worker and joins it however the provider ends: drained, refused by the
+// reader, or dropped by httplib without another call.
+class PumpJoiner {
+   public:
+    PumpJoiner(std::shared_ptr<StreamPump> pump, std::thread worker)
+        : pump_(std::move(pump)), worker_(std::move(worker)) {}
+    ~PumpJoiner() {
+        {
+            std::lock_guard<std::mutex> lock(pump_->mutex);
+            pump_->cancelled = true;
+        }
+        pump_->drained.notify_all();
+        if (worker_.joinable()) {
+            worker_.join();
+        }
+    }
+
+    PumpJoiner(const PumpJoiner&) = delete;
+    PumpJoiner& operator=(const PumpJoiner&) = delete;
+
+   private:
+    std::shared_ptr<StreamPump> pump_;
+    std::thread worker_;
+};
+
+void HandleStreaming(Runtime& runtime, const Json& request, httplib::Response& response) {
+    const std::string body = translate::RequestToOpenAI(request, runtime.model).dump();
+    const std::string path = runtime.prefix + "/chat/completions";
+    const std::string model = runtime.model;
+
+    auto pump = std::make_shared<StreamPump>();
+    std::thread worker([pump, origin = runtime.origin, path, api_key = runtime.api_key, model,
+                        body] { RunUpstream(pump, origin, path, api_key, model, body); });
+    auto joiner = std::make_shared<PumpJoiner>(pump, std::move(worker));
+
+    int status = 0;
+    {
+        std::unique_lock<std::mutex> lock(pump->mutex);
+        pump->ready.wait(lock, [&] { return pump->headers_known || pump->finished; });
+        status = pump->status;
+    }
+
+    if (status < 200 || status >= 300) {
+        // Nothing has been written downstream yet, so the refusal can be answered
+        // as itself: the upstream status, and the delay it asked for.
+        std::string error_body;
+        std::string retry_after;
+        {
+            std::unique_lock<std::mutex> lock(pump->mutex);
+            pump->ready.wait(lock, [&] { return pump->finished; });
+            error_body = pump->error_body;
+            retry_after = pump->retry_after;
+        }
+        LogUpstreamError(model, true, status, error_body);
+        response.status = status != 0 ? status : 502;
+        if (!retry_after.empty()) {
+            response.set_header("Retry-After", retry_after);
+        }
+        std::string type;
+        std::string message;
+        translate::UpstreamFailure(status, error_body, &type, &message);
+        response.set_content(translate::ErrorBody(type, message), "application/json");
+        return;
+    }
+
+    response.set_chunked_content_provider(
+        "text/event-stream", [pump, joiner](std::size_t /*offset*/, httplib::DataSink& sink) {
+            std::string events;
+            {
+                std::unique_lock<std::mutex> lock(pump->mutex);
+                pump->ready.wait(lock, [&] { return !pump->events.empty() || pump->finished; });
+                if (pump->events.empty()) {
+                    sink.done();
+                    return true;
+                }
+                events = std::move(pump->events.front());
+                pump->events.pop_front();
+                pump->queued_bytes -= events.size();
+                pump->drained.notify_all();
+            }
+            if (!sink.write(events.data(), events.size())) {
+                return false;
+            }
             return true;
         });
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,13 @@ target_link_libraries(test_wally_contract PRIVATE wally_core nlohmann_json::nloh
 wally_stage_windows_runtime_dlls(test_wally_contract)
 add_test(NAME wally_contract_tests COMMAND test_wally_contract --run-all)
 
+add_executable(test_wally_anthropic_shim test_wally_anthropic_shim.cpp)
+target_include_directories(test_wally_anthropic_shim PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(test_wally_anthropic_shim PRIVATE wally_core httplib::httplib
+    nlohmann_json::nlohmann_json)
+wally_stage_windows_runtime_dlls(test_wally_anthropic_shim)
+add_test(NAME wally_anthropic_shim_tests COMMAND test_wally_anthropic_shim --run-all)
+
 add_executable(test_wally_opencode test_wally_opencode.cpp)
 target_include_directories(test_wally_opencode PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(test_wally_opencode PRIVATE wally_core nlohmann_json::nlohmann_json)

--- a/tests/test_wally_anthropic_shim.cpp
+++ b/tests/test_wally_anthropic_shim.cpp
@@ -1,0 +1,355 @@
+// The Anthropic shim over a real socket.
+//
+// These run a mock upstream on loopback, start the real shim in front of it, and
+// talk to the shim with a real HTTP client. Nothing is stubbed, because the bug
+// they pin (#83) is an ordering bug between writing the downstream headers and
+// making the upstream call: a mocked transport cannot see it.
+
+#include "test_common.h"
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "anthropic/messages.h"
+#include "harness/harness.h"
+
+namespace {
+
+using Json = nlohmann::json;
+
+// A mock upstream OpenAI endpoint on its own port, torn down with the object.
+class Upstream {
+   public:
+    using Handler = std::function<void(const httplib::Request&, httplib::Response&)>;
+
+    explicit Upstream(Handler handler) {
+        server_.Post("/v1/chat/completions",
+                     [handler](const httplib::Request& request, httplib::Response& response) {
+                         handler(request, response);
+                     });
+        port_ = server_.bind_to_any_port("127.0.0.1");
+        thread_ = std::thread([this] { server_.listen_after_bind(); });
+        server_.wait_until_ready();
+    }
+
+    ~Upstream() {
+        server_.stop();
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    std::string base_url() const { return "http://127.0.0.1:" + std::to_string(port_) + "/v1"; }
+
+   private:
+    httplib::Server server_;
+    std::thread thread_;
+    int port_ = 0;
+};
+
+// The shim in front of `upstream`, stopped with the object.
+class Shim {
+   public:
+    explicit Shim(const Upstream& upstream) {
+        wally::harness::Endpoint endpoint;
+        endpoint.base_url = upstream.base_url();
+        started_ = wally::anthropic::Start(endpoint, "glm-5.3-flash", &shim_);
+    }
+    ~Shim() { wally::anthropic::Stop(&shim_); }
+
+    bool started() const { return started_; }
+    const wally::anthropic::Shim& handle() const { return shim_; }
+
+    // One POST /v1/messages, authenticated the way the wrapped tool does.
+    httplib::Result Post(const Json& body) const {
+        httplib::Client client("127.0.0.1", Port());
+        client.set_read_timeout(30, 0);
+        httplib::Headers headers{{"x-api-key", shim_.auth_token}};
+        return client.Post("/v1/messages", headers, body.dump(), "application/json");
+    }
+
+   private:
+    int Port() const {
+        const std::size_t colon = shim_.base_url.rfind(':');
+        return std::stoi(shim_.base_url.substr(colon + 1));
+    }
+
+    wally::anthropic::Shim shim_;
+    bool started_ = false;
+};
+
+// The text the stream actually carried, reassembled from its text_delta events.
+// OpenAI splits a word across chunks as it pleases, so the deltas are only
+// meaningful once they are joined back up.
+std::string StreamedText(const std::string& body) {
+    std::string text;
+    std::size_t at = 0;
+    const std::string marker = "data: ";
+    while ((at = body.find(marker, at)) != std::string::npos) {
+        at += marker.size();
+        const std::size_t end = body.find('\n', at);
+        if (end == std::string::npos) {
+            break;
+        }
+        Json event;
+        try {
+            event = Json::parse(body.substr(at, end - at));
+        } catch (const Json::exception&) {
+            continue;
+        }
+        if (event.value("type", "") == "content_block_delta") {
+            text += event["delta"].value("text", "");
+        }
+    }
+    return text;
+}
+
+Json StreamingRequest() {
+    return Json{{"model", "claude-sonnet-4"},
+                {"stream", true},
+                {"max_tokens", 128},
+                {"messages", Json::array({Json{{"role", "user"}, {"content", "hi"}}})}};
+}
+
+// A refusal the endpoint makes before it has produced a single token. This is the
+// case the client can still act on, so the status and the delay have to survive.
+TestResult test_streaming_overload_keeps_status_and_retry_after() {
+    TestResult result;
+    result.test_name = "streaming_overload_keeps_status_and_retry_after";
+
+    Upstream upstream([](const httplib::Request&, httplib::Response& response) {
+        response.status = 429;
+        response.set_header("Retry-After", "7");
+        response.set_content(Json{{"error", {{"message", "Too many parallel requests"}}}}.dump(),
+                             "application/json");
+    });
+    Shim shim(upstream);
+    if (!shim.started()) {
+        result.details = "the shim did not start";
+        return result;
+    }
+
+    const httplib::Result reply = shim.Post(StreamingRequest());
+    if (!reply) {
+        result.details = "the shim did not answer";
+        return result;
+    }
+    result.expected = "429 with Retry-After: 7";
+    result.actual = std::to_string(reply->status) + " with Retry-After: " +
+                    reply->get_header_value("Retry-After");
+    if (reply->status != 429) {
+        result.details = "a streaming overload must keep its 429, not become a 200 carrying an "
+                         "SSE error";
+        return result;
+    }
+    if (reply->get_header_value("Retry-After") != "7") {
+        result.details = "the upstream Retry-After must survive the streaming path";
+        return result;
+    }
+    // The failure is an error document, not a turn the model took.
+    Json body;
+    try {
+        body = Json::parse(reply->body);
+    } catch (const Json::exception& error) {
+        result.details = std::string("the 429 body is not JSON: ") + error.what();
+        return result;
+    }
+    if (body.value("type", "") != "error" ||
+        body["error"].value("type", "") != "rate_limit_error") {
+        result.details = "a 429 must read as an Anthropic rate_limit_error";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+// 503 has no Retry-After to carry, and must still arrive as itself.
+TestResult test_streaming_unavailable_keeps_its_status() {
+    TestResult result;
+    result.test_name = "streaming_unavailable_keeps_its_status";
+
+    Upstream upstream([](const httplib::Request&, httplib::Response& response) {
+        response.status = 503;
+        response.set_content(Json{{"error", {{"message", "no capacity"}}}}.dump(),
+                             "application/json");
+    });
+    Shim shim(upstream);
+    if (!shim.started()) {
+        result.details = "the shim did not start";
+        return result;
+    }
+
+    const httplib::Result reply = shim.Post(StreamingRequest());
+    if (!reply) {
+        result.details = "the shim did not answer";
+        return result;
+    }
+    result.expected = "503";
+    result.actual = std::to_string(reply->status);
+    if (reply->status != 503) {
+        result.details = "a streaming 503 must not be rewritten as a successful stream";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+// The ordinary path still streams, and still closes itself properly.
+TestResult test_streaming_success_still_streams() {
+    TestResult result;
+    result.test_name = "streaming_success_still_streams";
+
+    Upstream upstream([](const httplib::Request&, httplib::Response& response) {
+        const Json first{
+            {"choices", Json::array({Json{{"index", 0},
+                                          {"delta", {{"role", "assistant"}, {"content", "he"}}}}})}};
+        const Json second{
+            {"choices", Json::array({Json{{"index", 0}, {"delta", {{"content", "llo"}}}}})}};
+        const Json last{{"choices", Json::array({Json{{"index", 0},
+                                                      {"delta", Json::object()},
+                                                      {"finish_reason", "stop"}}})}};
+        const std::string body = "data: " + first.dump() + "\n\ndata: " + second.dump() +
+                                 "\n\ndata: " + last.dump() + "\n\ndata: [DONE]\n\n";
+        response.set_content(body, "text/event-stream");
+    });
+    Shim shim(upstream);
+    if (!shim.started()) {
+        result.details = "the shim did not start";
+        return result;
+    }
+
+    const httplib::Result reply = shim.Post(StreamingRequest());
+    if (!reply) {
+        result.details = "the shim did not answer";
+        return result;
+    }
+    result.expected = "200 with message_start, text, message_stop";
+    result.actual = std::to_string(reply->status) + " body=" + reply->body.substr(0, 200);
+    if (reply->status != 200) {
+        result.details = "a good stream must stay a 200";
+        return result;
+    }
+    const std::string text = StreamedText(reply->body);
+    result.actual = std::to_string(reply->status) + " text=" + text;
+    if (reply->body.find("event: message_start") == std::string::npos) {
+        result.details = "the translated stream lost its message_start";
+        return result;
+    }
+    if (text != "hello") {
+        result.details = "the translated stream lost its text, got: " + text;
+        return result;
+    }
+    if (reply->body.find("event: message_stop") == std::string::npos) {
+        result.details = "the translated stream lost its message_stop";
+        return result;
+    }
+    if (reply->body.find("event: error") != std::string::npos) {
+        result.details = "a successful stream must carry no error event";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+// The path that was already correct, kept correct: a non-streaming refusal.
+TestResult test_nonstreaming_overload_keeps_status_and_retry_after() {
+    TestResult result;
+    result.test_name = "nonstreaming_overload_keeps_status_and_retry_after";
+
+    Upstream upstream([](const httplib::Request&, httplib::Response& response) {
+        response.status = 429;
+        response.set_header("Retry-After", "3");
+        response.set_content(Json{{"error", {{"message", "slow down"}}}}.dump(),
+                             "application/json");
+    });
+    Shim shim(upstream);
+    if (!shim.started()) {
+        result.details = "the shim did not start";
+        return result;
+    }
+
+    Json request = StreamingRequest();
+    request["stream"] = false;
+    const httplib::Result reply = shim.Post(request);
+    if (!reply) {
+        result.details = "the shim did not answer";
+        return result;
+    }
+    result.expected = "429 with Retry-After: 3";
+    result.actual = std::to_string(reply->status) + " with Retry-After: " +
+                    reply->get_header_value("Retry-After");
+    if (reply->status != 429 || reply->get_header_value("Retry-After") != "3") {
+        result.details = "the non-streaming path lost the status or the delay";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+// A stream that dies after the first token. The 200 is already spent, so this can
+// only be a typed error event, but it must never look like a clean finish.
+TestResult test_stream_cut_short_is_an_error_not_a_clean_stop() {
+    TestResult result;
+    result.test_name = "stream_cut_short_is_an_error_not_a_clean_stop";
+
+    Upstream upstream([](const httplib::Request&, httplib::Response& response) {
+        const Json first{
+            {"choices", Json::array({Json{{"index", 0},
+                                          {"delta", {{"role", "assistant"}, {"content", "he"}}}}})}};
+        // Content-Length promises more than the body delivers, so the client sees
+        // the connection end mid-stream.
+        response.set_header("Content-Type", "text/event-stream");
+        response.set_content_provider(
+            4096, "text/event-stream",
+            [first](std::size_t, std::size_t, httplib::DataSink& sink) {
+                const std::string chunk = "data: " + first.dump() + "\n\n";
+                sink.write(chunk.data(), chunk.size());
+                return false;
+            });
+    });
+    Shim shim(upstream);
+    if (!shim.started()) {
+        result.details = "the shim did not start";
+        return result;
+    }
+
+    const httplib::Result reply = shim.Post(StreamingRequest());
+    if (!reply) {
+        // The shim's own connection died with the upstream's. That is a failure the
+        // client can see, which is the point of the test.
+        result.passed = true;
+        return result;
+    }
+    result.expected = "an error event, and no message_stop";
+    result.actual = "status=" + std::to_string(reply->status) + " body=" + reply->body.substr(0, 300);
+    if (reply->body.find("event: error") == std::string::npos) {
+        result.details = "a stream cut short must say so";
+        return result;
+    }
+    if (reply->body.find("event: message_stop") != std::string::npos) {
+        result.details = "a stream cut short must not be closed off as a normal turn";
+        return result;
+    }
+    result.passed = true;
+    return result;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    TestSuite suite("wally_anthropic_shim");
+    suite.add("streaming_overload_keeps_status_and_retry_after",
+              test_streaming_overload_keeps_status_and_retry_after);
+    suite.add("streaming_unavailable_keeps_its_status", test_streaming_unavailable_keeps_its_status);
+    suite.add("streaming_success_still_streams", test_streaming_success_still_streams);
+    suite.add("nonstreaming_overload_keeps_status_and_retry_after",
+              test_nonstreaming_overload_keeps_status_and_retry_after);
+    suite.add("stream_cut_short_is_an_error_not_a_clean_stop",
+              test_stream_cut_short_is_an_error_not_a_clean_stop);
+    return suite.run(argc, argv);
+}


### PR DESCRIPTION
Closes #83.

The Anthropic shim answered a streaming request with `200 OK` before it had made the upstream call, so an upstream `429` with `Retry-After: 7` reached the editor as a successful reply carrying an SSE error. The status was gone and so was the delay, which is the one piece of information a client needs in order to back off instead of retrying immediately into an endpoint that is already overloaded.

The non-streaming path was always correct, because it is synchronous. That is why rate-limit tests never caught this.

## Why it happened

`set_chunked_content_provider` makes httplib write the status and headers immediately, then run the provider callback afterwards. The upstream call lived inside that callback, so the 200 was committed before there was anything to base it on.

## The change

The upstream call runs on a worker thread, and the request handler waits for the upstream response *headers* before committing anything downstream. Headers are the first thing off the wire, so the wait costs nothing and does not buffer the body.

A pre-stream refusal now goes back as itself: the real status, the real `Retry-After`, and the same JSON error body the non-streaming path produces. A success installs the chunked provider, which drains a queue the worker fills with already-translated events, so the first token still starts the stream.

A failure after output has started stays a typed SSE error, since the 200 is genuinely spent by then. It is no longer followed by the closing events, so a truncated answer cannot read as a finished one.

The queue is capped and the worker waits when it is full, so a fast endpoint and a slow editor cannot grow it without bound. A joiner held by the provider's captures shuts the worker down however the stream ends, including when the reader hangs up and httplib never calls the provider again.

## Tests

New `tests/test_wally_anthropic_shim.cpp`, over real sockets: a mock upstream on a port, the real shim in front of it, a real client talking to the shim. Nothing is stubbed, because the bug is an ordering problem between the downstream header write and the upstream call, and a mocked transport cannot see it.

Five cases: a pre-stream 429 keeps its status and delay, a pre-stream 503 keeps its status, an ordinary stream still opens and closes properly, the non-streaming 429 stays correct, and a stream cut short after the first token ends as an error rather than a clean stop.

Break test, with the pre-stream status check disabled:

```
streaming_overload_keeps_status_and_retry_after
  Expected: 429 with Retry-After: 7
  Actual:   200 with Retry-After:

streaming_unavailable_keeps_its_status
  Expected: 503
  Actual:   200
```

Restored, 11 of 11 green.

Also checked by hand against the real binary, with a fake endpoint that always refuses. Before: `HTTP/1.1 200 OK` and no delay. After: `HTTP/1.1 429 Too Many Requests` with `Retry-After: 7`.

## Not in this change

`src/ide/openai_proxy.cpp` has the same bug and is #86. Fixing both here would put two issues in one diff.

Qualifying a real Claude client's retry timing against a counting endpoint is still open, as the issue notes. This makes the delay reach the client; it does not prove what the client does with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Streaming requests now preserve upstream HTTP status codes instead of incorrectly returning success.
  - Rate-limit responses retain the `Retry-After` information and are surfaced with the appropriate error details.
  - Service-unavailable responses are reported accurately.
  - Interrupted streams now emit an error rather than appearing to complete successfully.
  - Successful streaming responses continue to deliver translated events without spurious errors.

- **Tests**
  - Added coverage for streaming and non-streaming errors, rate limits, successful event delivery, and interrupted connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->